### PR TITLE
Update guidelines and flake

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,5 +7,7 @@
   ```
 
 - A Nix flake is provided. You can enter the dev environment with `nix develop` and build with `nix build`.
+- Use `nix develop` (or `nix run`) when invoking `cargo` and `cargo nextest` commands.
 - Run tests with `cargo nextest run --workspace --all-targets --profile ci`.
+- `cargo fmt --check`, `cargo clippy -- -D warnings`, and `nix flake check` must all pass before work is ready.
 

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,7 @@
               pkgs.rust-analyzer
               pkgs.clippy
               pkgs.rustfmt
+              pkgs.cargo-nextest
             ];
           };
         }


### PR DESCRIPTION
## Summary
- include `cargo-nextest` in the development shell
- document using `nix` for running `cargo` commands and checks

## Testing
- `nix develop -c cargo fmt -- --check` *(fails: interrupted by the user)*

------
https://chatgpt.com/codex/tasks/task_e_68472af434b0832785eedea8277914e8