### PR TITLE
Add nix build docs

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -1,0 +1,18 @@
+name: Nix Build
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v6
+      - uses: DeterminateSystems/flakehub-cache-action@main
+      - name: Build package
+        run: nix build .#middle_manager

--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ All workspace crates reside in the `crates/` directory to keep the repository ro
 
 Run `cargo build` from the repository root to compile all crates.
 
+### Using Nix
+
+If you have [Nix](https://nixos.org/) installed you can build the CLI package with:
+
+```bash
+nix build .#middle_manager
+```
+
+The [Determinate Systems installer](https://install.determinate.systems/nix) provides a fast way to install Nix:
+
+```bash
+curl -L https://install.determinate.systems/nix | sh -s -- --no-confirm
+```
+
 ## Running
 
 Execute `cargo run -p mm-cli` to build and run the CLI with default settings.

--- a/flake.nix
+++ b/flake.nix
@@ -16,8 +16,9 @@
           pkgs = import nixpkgs { inherit system; overlays = [ rust-overlay.overlays.default ]; };
           naersk-lib = pkgs.callPackage naersk { };
         in
-        {
-          default = naersk-lib.buildPackage {
+        rec {
+          middle_manager = naersk-lib.buildPackage {
+            pname = "middle_manager";
             src = self;
             cargoLock = ./Cargo.lock;
             nativeBuildInputs = with pkgs; [
@@ -28,7 +29,17 @@
               openssl
               openssl.dev
             ];
+            overrideMain = old: {
+              preConfigure = (old.preConfigure or "") + ''
+                cargo_build_options="$cargo_build_options -p mm-cli"
+              '';
+            };
+            postInstall = ''
+              mv $out/bin/mm-cli $out/bin/middle_manager
+            '';
           };
+
+          default = middle_manager;
         }
       );
 


### PR DESCRIPTION
## Summary
- document how to build with Nix and install with Determinate Systems' installer
- the flake exposes `middle_manager` package built via naersk
- Nix build workflow uses Determinate Systems installer and FlakeHub cache

## Testing
- `cargo test`
- `nix build .#middle_manager` *(partially ran, heavy downloads)*

------
https://chatgpt.com/codex/tasks/task_e_684a6a0d9594832784b6c24f01f3d08f