### PR TITLE
Add more unit tests and fix build issues

### DIFF
--- a/crates/mm-core/src/operations/create_entity.rs
+++ b/crates/mm-core/src/operations/create_entity.rs
@@ -64,3 +64,49 @@ pub async fn create_entity(ports: &Ports, command: CreateEntityCommand) -> Creat
         Err(e) => Err(CreateEntityError::Repository(e)),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::MockMemoryService;
+    use mockall::predicate::*;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_create_entity_success() {
+        let mut mock = MockMemoryService::<neo4rs::Error>::new();
+        mock.expect_create_entity()
+            .withf(|e| e.name == "test:entity")
+            .returning(|_| Ok(()));
+
+        let ports = Ports::new(Arc::new(mock));
+
+        let command = CreateEntityCommand {
+            name: "test:entity".to_string(),
+            labels: vec!["Test".to_string()],
+            observations: vec![],
+            properties: HashMap::new(),
+        };
+
+        let result = create_entity(&ports, command).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_create_entity_empty_name() {
+        let mut mock = MockMemoryService::<neo4rs::Error>::new();
+        mock.expect_create_entity().never();
+
+        let ports = Ports::new(Arc::new(mock));
+
+        let command = CreateEntityCommand {
+            name: "".to_string(),
+            labels: vec!["Test".to_string()],
+            observations: vec![],
+            properties: HashMap::new(),
+        };
+
+        let result = create_entity(&ports, command).await;
+        assert!(matches!(result, Err(CreateEntityError::Validation(_))));
+    }
+}

--- a/crates/mm-server/src/lib.rs
+++ b/crates/mm-server/src/lib.rs
@@ -146,14 +146,13 @@ mod tests {
     use mm_core::MemoryServiceImpl;
     use rust_mcp_sdk::error::McpSdkError;
     use rust_mcp_sdk::error::SdkResult;
-    use rust_mcp_sdk::schema::ClientMessage;
     use rust_mcp_sdk::schema::InitializeRequestParams;
+    use rust_mcp_sdk::schema::schema_utils::ClientMessage;
     use rust_mcp_sdk::schema::{
         Implementation, InitializeResult, LATEST_PROTOCOL_VERSION, ServerCapabilities,
         schema_utils::NotificationFromServer,
     };
-    use rust_mcp_sdk::transport::McpDispatch;
-    use rust_mcp_sdk::transport::MessageDispatcher;
+    use rust_mcp_sdk::{McpDispatch, MessageDispatcher};
     use serde_json::Value;
     use std::future::Future;
     use std::option::Option;


### PR DESCRIPTION
## Summary
- add new tests for operations in mm-core
- remove the ignore attribute so Neo4j integration tests run by default
- fix mm-server test imports so crate compiles

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test --workspace` *(fails: connection refused)*
- `docker compose up -d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a79a5760083279f26746fb39affc2