### PR TITLE
Add cargo check job and keep test flags clear

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,18 @@ jobs:
         with:
           args: --workspace --all-targets -- -D warnings
 
+  check:
+    name: Cargo Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Cargo check
+        run: cargo check --workspace --all-targets
+
   test:
     name: Tests
     runs-on: ubuntu-latest
@@ -40,6 +52,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
+          rustflags: ""
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with:


### PR DESCRIPTION
## Summary
- add `cargo check` job
- keep default `-D warnings` for cargo check job
- disable `-D warnings` for test job

## Testing
- `cargo test --workspace --lib`


------
https://chatgpt.com/codex/tasks/task_e_684b13c9ce48832796c0cc874c1ce8ac