### PR TITLE
Add LLVM coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   fmt:
     name: Rustfmt


### PR DESCRIPTION
## Summary
- collect test coverage via `cargo llvm-cov`
- publish `lcov.info` on PRs using `report-lcov` action

## Testing
- `cargo test --workspace --lib`

------
https://chatgpt.com/codex/tasks/task_e_684b253a81e483279ef126facc4c0fb9