### PR TITLE
Fix .gitignore to track Cargo.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # Rust build artifacts
 /target/
 **/*.rs.bk
-Cargo.lock
 
 # IDE files
 .idea/


### PR DESCRIPTION
## Summary
- stop ignoring `Cargo.lock`

## Testing
- `cargo test --workspace --lib`


------
https://chatgpt.com/codex/tasks/task_e_684b2c9977648327bc6883a49e97cca5