### PR TITLE
Clarify Neo4j port for Docker users

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ username = "neo4j"
 password = "password"
 ```
 
+When using the provided `docker-compose.yml` file, Neo4j is exposed on host
+port `7688` rather than the default `7687`. Update `config/local.toml` or set
+the environment variable `MM_NEO4J__URI` to `neo4j://localhost:7688` when
+running with Docker.
+
 ## Development
 
 ### Using Just


### PR DESCRIPTION
## Summary
- document that docker-compose exposes Neo4j on port 7688
- mention editing `config/local.toml` or using `MM_NEO4J__URI`

## Testing
- `cargo test --workspace` *(fails: connection refused because Neo4j isn't running)*

------
https://chatgpt.com/codex/tasks/task_e_684b2c97fa9c83278bc6429f2b56f6aa