### PR TITLE
Update mm-cli to Rust 2024 edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ graph TD
 
 Run `cargo build` from the repository root to compile all crates.
 
+The workspace requires the **Rust 2024 edition**, so ensure your toolchain is up to date.
+
 ### Using Nix
 
 If you have [Nix](https://nixos.org/) installed you can build the CLI package with:

--- a/crates/mm-cli/Cargo.toml
+++ b/crates/mm-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mm-cli"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 default-run = "mm-cli"
 
 [dependencies]

--- a/crates/mm-cli/src/main.rs
+++ b/crates/mm-cli/src/main.rs
@@ -2,18 +2,18 @@ use clap::{Parser, ValueEnum};
 use std::fs::{File, OpenOptions};
 use std::io;
 use std::path::{Path, PathBuf};
-use tracing::{debug, info, Level};
+use tracing::{Level, debug, info};
 use tracing_subscriber::fmt::writer::MakeWriterExt;
-use tracing_subscriber::{fmt, prelude::*, EnvFilter, Registry};
+use tracing_subscriber::{EnvFilter, Registry, fmt, prelude::*};
 
-use mm_core::{create_neo4j_service, neo4rs, Config};
+use mm_core::{Config, create_neo4j_service, neo4rs};
 use rust_mcp_sdk::{
+    McpServer, StdioTransport, TransportOptions,
     mcp_server::server_runtime_core,
     schema::{
-        Implementation, InitializeResult, ServerCapabilities, ServerCapabilitiesTools,
-        LATEST_PROTOCOL_VERSION,
+        Implementation, InitializeResult, LATEST_PROTOCOL_VERSION, ServerCapabilities,
+        ServerCapabilitiesTools,
     },
-    McpServer, StdioTransport, TransportOptions,
 };
 
 /// Middle Manager CLI


### PR DESCRIPTION
## Summary
- set `edition = "2024"` for the `mm-cli` crate
- note the new edition requirement in the README
- run `cargo fmt` and update formatted imports

## Testing
- `cargo fmt --all`
- `cargo test --workspace --lib`

------
https://chatgpt.com/codex/tasks/task_e_684b2e14b10083279f11bea26646ff4d