### PR TITLE
refactor: Move config to server crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,7 +1320,6 @@ name = "mm-core"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "config",
  "mm-memory-neo4j",
  "mockall",
  "serde",
@@ -1350,6 +1349,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "config",
  "mm-core",
  "mm-memory-neo4j",
  "rust-mcp-sdk",

--- a/crates/mm-core/Cargo.toml
+++ b/crates/mm-core/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 
 [dependencies]
 mm-memory-neo4j = { path = "../mm-memory-neo4j" }
-config = "0.15.11"
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/mm-core/src/lib.rs
+++ b/crates/mm-core/src/lib.rs
@@ -1,10 +1,8 @@
-mod config;
 pub mod error;
 mod operations;
 mod ports;
 mod service;
 
-pub use config::Config;
 pub use error::{CoreError, Error, Result as CoreResult};
 pub use operations::{
     CreateEntityCommand, CreateEntityError, CreateEntityResult, GetEntityCommand, GetEntityError,

--- a/crates/mm-server/Cargo.toml
+++ b/crates/mm-server/Cargo.toml
@@ -18,3 +18,4 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 anyhow = "1.0"
 async-trait = { workspace = true }
+config = "0.15.11"

--- a/crates/mm-server/src/config.rs
+++ b/crates/mm-server/src/config.rs
@@ -3,7 +3,7 @@ use mm_memory_neo4j::{MemoryConfig, Neo4jConfig};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
-/// Configuration for mm-core
+/// Configuration for mm-server
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Config {
     /// Neo4j configuration

--- a/crates/mm-server/src/lib.rs
+++ b/crates/mm-server/src/lib.rs
@@ -5,7 +5,10 @@ use std::sync::Arc;
 
 use anyhow::Result as AnyResult;
 
-use mm_core::{Config, MemoryService, Ports, create_neo4j_service, neo4rs};
+use mm_core::{MemoryService, Ports, create_neo4j_service, neo4rs};
+
+mod config;
+pub use config::Config;
 
 use rust_mcp_sdk::schema::{
     ClientRequest, ListToolsResult, RpcError,


### PR DESCRIPTION
## Summary
- move `Config` from `mm-core` to `mm-server`
- update imports and dependencies

## Testing
- `cargo test --workspace --lib`

------
https://chatgpt.com/codex/tasks/task_e_684c497cd4948327b6f498a68ff2b8c1