### PR TITLE
chore: Introduce mm-utils crate and migrate utility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1360,6 +1360,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "mm-utils"
+version = "0.1.0"
+
+[[package]]
 name = "mockall"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/mm-cli", "crates/mm-core", "crates/mm-memory-neo4j", "crates/mm-server"]
+members = ["crates/mm-cli", "crates/mm-core", "crates/mm-memory-neo4j", "crates/mm-server", "crates/mm-utils"]
 resolver = "3"
 default-members = ["crates/mm-cli"]
 

--- a/crates/mm-core/src/lib.rs
+++ b/crates/mm-core/src/lib.rs
@@ -2,7 +2,6 @@ pub mod error;
 mod operations;
 mod ports;
 mod service;
-pub mod utils;
 
 pub use error::{CoreError, Error, Result as CoreResult};
 pub use operations::{

--- a/crates/mm-utils/Cargo.toml
+++ b/crates/mm-utils/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "mm-utils"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/crates/mm-utils/src/lib.rs
+++ b/crates/mm-utils/src/lib.rs
@@ -1,13 +1,15 @@
-//! Utility functions for common tasks within mm-core
-/// Check if a string is in snake_case format
+//! Utility helpers that are independent from the rest of the project.
+
+/// Check if a string is in snake_case format.
 ///
 /// This function verifies that all characters are lowercase, digits, or
-/// underscores. It is used when validating entity names or other identifiers.
+/// underscores. It can be used when validating identifiers or any string that
+/// must follow the snake_case convention.
 ///
 /// # Examples
 ///
 /// ```
-/// use mm_core::utils::is_snake_case;
+/// use mm_utils::is_snake_case;
 ///
 /// assert!(is_snake_case("hello_world"));
 /// assert!(is_snake_case("hello"));


### PR DESCRIPTION
## Summary
- add new standalone `mm-utils` crate
- migrate `is_snake_case` utility and tests into `mm-utils`
- remove unused utils module from `mm-core`
- include `mm-utils` in workspace

## Testing
- `cargo test --workspace --lib`

------
https://chatgpt.com/codex/tasks/task_e_684c7e00d6a48327aa4499a92ef85867