### PR TITLE
tests(memory): Add repository error tests

### DIFF
--- a/crates/mm-core/Cargo.toml
+++ b/crates/mm-core/Cargo.toml
@@ -14,3 +14,4 @@ async-trait = { workspace = true }
 [dev-dependencies]
 mockall = { workspace = true }
 tokio = { workspace = true, features = ["full", "test-util"] }
+mm-memory = { path = "../mm-memory", features = ["mock"] }


### PR DESCRIPTION
## Summary
- add dev dependency for mm-core tests to use mock memory repository
- cover repository error handling in `create_entity`
- cover repository error handling in `get_entity`

## Testing
- `cargo test -p mm-core`

------
https://chatgpt.com/codex/tasks/task_e_6850a07c82488327bc5d2b104487e323