### PR TITLE
tests(memory): Add repository error tests for observation ops

### DIFF
--- a/crates/mm-core/src/operations/set_observations.rs
+++ b/crates/mm-core/src/operations/set_observations.rs
@@ -54,7 +54,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
+    use mm_memory::{MemoryConfig, MemoryError, MemoryService, MockMemoryRepository};
     use std::sync::Arc;
 
     #[tokio::test]
@@ -85,5 +85,24 @@ mod tests {
         };
         let result = set_observations(&ports, command).await;
         assert!(matches!(result, Err(SetObservationsError::Validation(_))));
+    }
+
+    #[tokio::test]
+    async fn test_set_observations_repository_error() {
+        let mut mock = MockMemoryRepository::new();
+        mock.expect_set_observations()
+            .withf(|name, _| name == "test:entity")
+            .returning(|_, _| Err(MemoryError::runtime_error("fail")));
+        let service = MemoryService::new(mock, MemoryConfig::default());
+        let ports = Ports::new(Arc::new(service));
+        let command = SetObservationsCommand {
+            name: "test:entity".to_string(),
+            observations: vec!["obs".to_string()],
+        };
+        let result = set_observations(&ports, command).await;
+        assert!(matches!(
+            result,
+            Err(SetObservationsError::Repository(CoreError::Memory(_)))
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- expand tests in `add_observations`, `set_observations`,
  `remove_all_observations` and `remove_observations`
- ensure repository error branches use `MockMemoryRepository`

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_6850c453a8388327bf3bbc59cf849351