### PR TITLE
refactor(memory): Refactor tool error handling

### DIFF
--- a/crates/mm-server/src/mcp/create_entity.rs
+++ b/crates/mm-server/src/mcp/create_entity.rs
@@ -5,9 +5,8 @@ use rust_mcp_sdk::schema::CallToolResult;
 use rust_mcp_sdk::schema::schema_utils::CallToolError;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use tracing::error;
 
-use crate::mcp::error::ToolError;
+use crate::mcp::error::map_result;
 
 /// MCP tool for creating entities
 #[mcp_tool(
@@ -45,20 +44,13 @@ impl CreateEntityTool {
             properties: self.properties.clone().unwrap_or_default(),
         };
 
-        // Execute the operation
-        match create_entity(ports, command).await {
-            Ok(_) => Ok(CallToolResult::text_content(
+        // Execute the operation and map the result
+        map_result(create_entity(ports, command).await).map(|_| {
+            CallToolResult::text_content(
                 format!("Entity '{}' created successfully", self.name),
                 None,
-            )),
-            Err(e) => {
-                // Log the detailed error
-                error!("Failed to create entity: {:#?}", e);
-                // Return a simplified error for the MCP protocol
-                let tool_error = ToolError::from(e);
-                Err(CallToolError::new(tool_error))
-            }
-        }
+            )
+        })
     }
 }
 

--- a/crates/mm-server/src/mcp/remove_all_observations.rs
+++ b/crates/mm-server/src/mcp/remove_all_observations.rs
@@ -1,3 +1,4 @@
+use crate::mcp::error::map_result;
 use mm_core::{Ports, RemoveAllObservationsCommand, remove_all_observations};
 use mm_memory::MemoryRepository;
 use mm_memory_neo4j::neo4rs;
@@ -5,9 +6,6 @@ use rust_mcp_sdk::macros::{JsonSchema, mcp_tool};
 use rust_mcp_sdk::schema::CallToolResult;
 use rust_mcp_sdk::schema::schema_utils::CallToolError;
 use serde::{Deserialize, Serialize};
-use tracing::error;
-
-use crate::mcp::error::ToolError;
 
 #[mcp_tool(
     name = "remove_all_observations",
@@ -27,16 +25,11 @@ impl RemoveAllObservationsTool {
             name: self.name.clone(),
         };
 
-        match remove_all_observations(ports, command).await {
-            Ok(_) => Ok(CallToolResult::text_content(
+        map_result(remove_all_observations(ports, command).await).map(|_| {
+            CallToolResult::text_content(
                 format!("All observations removed from '{}'", self.name),
                 None,
-            )),
-            Err(e) => {
-                error!("Failed to remove observations: {:#?}", e);
-                let tool_error = ToolError::from(e);
-                Err(CallToolError::new(tool_error))
-            }
-        }
+            )
+        })
     }
 }

--- a/crates/mm-server/src/mcp/set_observations.rs
+++ b/crates/mm-server/src/mcp/set_observations.rs
@@ -1,3 +1,4 @@
+use crate::mcp::error::map_result;
 use mm_core::{Ports, SetObservationsCommand, set_observations};
 use mm_memory::MemoryRepository;
 use mm_memory_neo4j::neo4rs;
@@ -5,9 +6,6 @@ use rust_mcp_sdk::macros::{JsonSchema, mcp_tool};
 use rust_mcp_sdk::schema::CallToolResult;
 use rust_mcp_sdk::schema::schema_utils::CallToolError;
 use serde::{Deserialize, Serialize};
-use tracing::error;
-
-use crate::mcp::error::ToolError;
 
 #[mcp_tool(
     name = "set_observations",
@@ -29,16 +27,8 @@ impl SetObservationsTool {
             observations: self.observations.clone(),
         };
 
-        match set_observations(ports, command).await {
-            Ok(_) => Ok(CallToolResult::text_content(
-                format!("Observations for '{}' replaced", self.name),
-                None,
-            )),
-            Err(e) => {
-                error!("Failed to set observations: {:#?}", e);
-                let tool_error = ToolError::from(e);
-                Err(CallToolError::new(tool_error))
-            }
-        }
+        map_result(set_observations(ports, command).await).map(|_| {
+            CallToolResult::text_content(format!("Observations for '{}' replaced", self.name), None)
+        })
     }
 }


### PR DESCRIPTION
## Summary
- add `map_result` helper for mapping tool errors
- use the helper in all tool implementations

## Testing
- `cargo test -p mm-server --quiet`
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_6850c741d07c83278108002df868b570