### PR TITLE
Use CoreError directly in operations

### DIFF
--- a/crates/mm-core/src/lib.rs
+++ b/crates/mm-core/src/lib.rs
@@ -5,14 +5,10 @@ mod ports;
 pub use error::{CoreError, CoreResult};
 pub use mm_memory::MemoryService;
 pub use operations::{
-    AddObservationsCommand, AddObservationsError, AddObservationsResult, CreateEntityCommand,
-    CreateEntityError, CreateEntityResult, CreateRelationshipCommand, CreateRelationshipError,
-    CreateRelationshipResult, GetEntityCommand, GetEntityError, GetEntityResult,
-    RemoveAllObservationsCommand, RemoveAllObservationsError, RemoveAllObservationsResult,
-    RemoveObservationsCommand, RemoveObservationsError, RemoveObservationsResult,
-    SetObservationsCommand, SetObservationsError, SetObservationsResult, add_observations,
-    create_entity, create_relationship, get_entity, remove_all_observations, remove_observations,
-    set_observations,
+    AddObservationsCommand, CreateEntityCommand, CreateEntityResult, CreateRelationshipCommand,
+    GetEntityCommand, GetEntityResult, RemoveAllObservationsCommand, RemoveObservationsCommand,
+    SetObservationsCommand, add_observations, create_entity, create_relationship, get_entity,
+    remove_all_observations, remove_observations, set_observations,
 };
 pub use ports::Ports;
 

--- a/crates/mm-core/src/operations/create_entity.rs
+++ b/crates/mm-core/src/operations/create_entity.rs
@@ -1,9 +1,8 @@
 use crate::MemoryEntity;
-use crate::error::CoreError;
+use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
-use mm_memory::MemoryRepository;
+use mm_memory::{MemoryRepository, ValidationError};
 use std::collections::HashMap;
-use thiserror::Error;
 
 /// Command to create a new entity
 #[derive(Debug, Clone)]
@@ -14,21 +13,8 @@ pub struct CreateEntityCommand {
     pub properties: HashMap<String, String>,
 }
 
-/// Error types that can occur when creating an entity
-#[derive(Debug, Error)]
-pub enum CreateEntityError<E>
-where
-    E: std::error::Error + Send + Sync + 'static,
-{
-    #[error("Repository error: {0}")]
-    Repository(#[from] CoreError<E>),
-
-    #[error("Validation error: {0}")]
-    Validation(String),
-}
-
 /// Result type for the create_entity operation
-pub type CreateEntityResult<E> = Result<(), CreateEntityError<E>>;
+pub type CreateEntityResult<E> = CoreResult<(), E>;
 
 /// Create a new entity
 ///
@@ -50,15 +36,13 @@ where
 {
     // Validate command
     if command.name.is_empty() {
-        return Err(CreateEntityError::Validation(
-            "Entity name cannot be empty".to_string(),
-        ));
+        return Err(CoreError::Validation(ValidationError::EmptyEntityName));
     }
 
     if command.labels.is_empty() {
-        return Err(CreateEntityError::Validation(
-            "Entity must have at least one label".to_string(),
-        ));
+        return Err(CoreError::Validation(ValidationError::NoLabels(
+            command.name.clone(),
+        )));
     }
 
     // Create entity using the memory service
@@ -71,7 +55,7 @@ where
 
     match ports.memory_service.create_entity(&entity).await {
         Ok(_) => Ok(()),
-        Err(e) => Err(CreateEntityError::Repository(CoreError::from(e))),
+        Err(e) => Err(CoreError::from(e)),
     }
 }
 
@@ -119,7 +103,7 @@ mod tests {
         };
 
         let result = create_entity(&ports, command).await;
-        assert!(matches!(result, Err(CreateEntityError::Validation(_))));
+        assert!(matches!(result, Err(CoreError::Validation(_))));
     }
 
     #[tokio::test]
@@ -144,9 +128,6 @@ mod tests {
 
         let result = create_entity(&ports, command).await;
 
-        assert!(matches!(
-            result,
-            Err(CreateEntityError::Repository(CoreError::Memory(_)))
-        ));
+        assert!(matches!(result, Err(CoreError::Memory(_))));
     }
 }

--- a/crates/mm-core/src/operations/mod.rs
+++ b/crates/mm-core/src/operations/mod.rs
@@ -1,4 +1,3 @@
-#![allow(unused_imports)]
 pub mod add_observations;
 pub mod create_entity;
 pub mod create_relationship;
@@ -7,25 +6,10 @@ pub mod remove_all_observations;
 pub mod remove_observations;
 pub mod set_observations;
 
-pub use add_observations::{
-    AddObservationsCommand, AddObservationsError, AddObservationsResult, add_observations,
-};
-pub use create_entity::{
-    CreateEntityCommand, CreateEntityError, CreateEntityResult, create_entity,
-};
-pub use create_relationship::{
-    CreateRelationshipCommand, CreateRelationshipError, CreateRelationshipResult,
-    create_relationship,
-};
-pub use get_entity::{GetEntityCommand, GetEntityError, GetEntityResult, get_entity};
-pub use remove_all_observations::{
-    RemoveAllObservationsCommand, RemoveAllObservationsError, RemoveAllObservationsResult,
-    remove_all_observations,
-};
-pub use remove_observations::{
-    RemoveObservationsCommand, RemoveObservationsError, RemoveObservationsResult,
-    remove_observations,
-};
-pub use set_observations::{
-    SetObservationsCommand, SetObservationsError, SetObservationsResult, set_observations,
-};
+pub use add_observations::{AddObservationsCommand, add_observations};
+pub use create_entity::{CreateEntityCommand, CreateEntityResult, create_entity};
+pub use create_relationship::{CreateRelationshipCommand, create_relationship};
+pub use get_entity::{GetEntityCommand, GetEntityResult, get_entity};
+pub use remove_all_observations::{RemoveAllObservationsCommand, remove_all_observations};
+pub use remove_observations::{RemoveObservationsCommand, remove_observations};
+pub use set_observations::{SetObservationsCommand, set_observations};

--- a/crates/mm-core/src/operations/remove_observations.rs
+++ b/crates/mm-core/src/operations/remove_observations.rs
@@ -1,44 +1,23 @@
-use crate::error::CoreError;
+use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
-use mm_memory::MemoryRepository;
-use thiserror::Error;
+use mm_memory::{MemoryRepository, ValidationError};
 
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct RemoveObservationsCommand {
     pub name: String,
     pub observations: Vec<String>,
 }
 
-#[derive(Debug, Error)]
-#[allow(dead_code)]
-pub enum RemoveObservationsError<E>
-where
-    E: std::error::Error + Send + Sync + 'static,
-{
-    #[error("Repository error: {0}")]
-    Repository(#[from] CoreError<E>),
-
-    #[error("Validation error: {0}")]
-    Validation(String),
-}
-
-#[allow(dead_code)]
-pub type RemoveObservationsResult<E> = Result<(), RemoveObservationsError<E>>;
-
-#[allow(dead_code)]
 pub async fn remove_observations<R>(
     ports: &Ports<R>,
     command: RemoveObservationsCommand,
-) -> RemoveObservationsResult<R::Error>
+) -> CoreResult<(), R::Error>
 where
     R: MemoryRepository + Send + Sync,
     R::Error: std::error::Error + Send + Sync + 'static,
 {
     if command.name.is_empty() {
-        return Err(RemoveObservationsError::Validation(
-            "Entity name cannot be empty".to_string(),
-        ));
+        return Err(CoreError::Validation(ValidationError::EmptyEntityName));
     }
 
     match ports
@@ -47,7 +26,7 @@ where
         .await
     {
         Ok(_) => Ok(()),
-        Err(e) => Err(RemoveObservationsError::Repository(CoreError::from(e))),
+        Err(e) => Err(CoreError::from(e)),
     }
 }
 
@@ -84,10 +63,7 @@ mod tests {
             observations: vec![],
         };
         let result = remove_observations(&ports, command).await;
-        assert!(matches!(
-            result,
-            Err(RemoveObservationsError::Validation(_))
-        ));
+        assert!(matches!(result, Err(CoreError::Validation(_))));
     }
 
     #[tokio::test]
@@ -103,9 +79,6 @@ mod tests {
             observations: vec!["obs".to_string()],
         };
         let result = remove_observations(&ports, command).await;
-        assert!(matches!(
-            result,
-            Err(RemoveObservationsError::Repository(CoreError::Memory(_)))
-        ));
+        assert!(matches!(result, Err(CoreError::Memory(_))));
     }
 }

--- a/crates/mm-core/src/operations/set_observations.rs
+++ b/crates/mm-core/src/operations/set_observations.rs
@@ -1,44 +1,23 @@
-use crate::error::CoreError;
+use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
-use mm_memory::MemoryRepository;
-use thiserror::Error;
+use mm_memory::{MemoryRepository, ValidationError};
 
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct SetObservationsCommand {
     pub name: String,
     pub observations: Vec<String>,
 }
 
-#[derive(Debug, Error)]
-#[allow(dead_code)]
-pub enum SetObservationsError<E>
-where
-    E: std::error::Error + Send + Sync + 'static,
-{
-    #[error("Repository error: {0}")]
-    Repository(#[from] CoreError<E>),
-
-    #[error("Validation error: {0}")]
-    Validation(String),
-}
-
-#[allow(dead_code)]
-pub type SetObservationsResult<E> = Result<(), SetObservationsError<E>>;
-
-#[allow(dead_code)]
 pub async fn set_observations<R>(
     ports: &Ports<R>,
     command: SetObservationsCommand,
-) -> SetObservationsResult<R::Error>
+) -> CoreResult<(), R::Error>
 where
     R: MemoryRepository + Send + Sync,
     R::Error: std::error::Error + Send + Sync + 'static,
 {
     if command.name.is_empty() {
-        return Err(SetObservationsError::Validation(
-            "Entity name cannot be empty".to_string(),
-        ));
+        return Err(CoreError::Validation(ValidationError::EmptyEntityName));
     }
 
     match ports
@@ -47,7 +26,7 @@ where
         .await
     {
         Ok(_) => Ok(()),
-        Err(e) => Err(SetObservationsError::Repository(CoreError::from(e))),
+        Err(e) => Err(CoreError::from(e)),
     }
 }
 
@@ -84,7 +63,7 @@ mod tests {
             observations: vec![],
         };
         let result = set_observations(&ports, command).await;
-        assert!(matches!(result, Err(SetObservationsError::Validation(_))));
+        assert!(matches!(result, Err(CoreError::Validation(_))));
     }
 
     #[tokio::test]
@@ -100,9 +79,6 @@ mod tests {
             observations: vec!["obs".to_string()],
         };
         let result = set_observations(&ports, command).await;
-        assert!(matches!(
-            result,
-            Err(SetObservationsError::Repository(CoreError::Memory(_)))
-        ));
+        assert!(matches!(result, Err(CoreError::Memory(_))));
     }
 }

--- a/crates/mm-server/src/mcp/error.rs
+++ b/crates/mm-server/src/mcp/error.rs
@@ -1,8 +1,5 @@
 use mm_core::CoreError;
-use mm_core::{
-    AddObservationsError, CreateEntityError, CreateRelationshipError, GetEntityError,
-    RemoveAllObservationsError, RemoveObservationsError, SetObservationsError,
-};
+
 use std::error::Error as StdError;
 use std::fmt;
 
@@ -47,72 +44,6 @@ where
 {
     fn from(error: CoreError<E>) -> Self {
         Self::with_source(format!("{:#?}", error), error)
-    }
-}
-
-impl<E> From<CreateEntityError<E>> for ToolError
-where
-    E: StdError + Send + Sync + 'static,
-{
-    fn from(error: CreateEntityError<E>) -> Self {
-        Self::with_source(format!("Create entity error: {:#?}", error), error)
-    }
-}
-
-impl<E> From<GetEntityError<E>> for ToolError
-where
-    E: StdError + Send + Sync + 'static,
-{
-    fn from(error: GetEntityError<E>) -> Self {
-        Self::with_source(format!("Get entity error: {:#?}", error), error)
-    }
-}
-
-impl<E> From<SetObservationsError<E>> for ToolError
-where
-    E: StdError + Send + Sync + 'static,
-{
-    fn from(error: SetObservationsError<E>) -> Self {
-        Self::with_source(format!("Set observations error: {:#?}", error), error)
-    }
-}
-
-impl<E> From<AddObservationsError<E>> for ToolError
-where
-    E: StdError + Send + Sync + 'static,
-{
-    fn from(error: AddObservationsError<E>) -> Self {
-        Self::with_source(format!("Add observations error: {:#?}", error), error)
-    }
-}
-
-impl<E> From<RemoveAllObservationsError<E>> for ToolError
-where
-    E: StdError + Send + Sync + 'static,
-{
-    fn from(error: RemoveAllObservationsError<E>) -> Self {
-        Self::with_source(
-            format!("Remove all observations error: {:#?}", error),
-            error,
-        )
-    }
-}
-
-impl<E> From<RemoveObservationsError<E>> for ToolError
-where
-    E: StdError + Send + Sync + 'static,
-{
-    fn from(error: RemoveObservationsError<E>) -> Self {
-        Self::with_source(format!("Remove observations error: {:#?}", error), error)
-    }
-}
-
-impl<E> From<CreateRelationshipError<E>> for ToolError
-where
-    E: StdError + Send + Sync + 'static,
-{
-    fn from(error: CreateRelationshipError<E>) -> Self {
-        Self::with_source(format!("Create relationship error: {:#?}", error), error)
     }
 }
 


### PR DESCRIPTION
## Summary
- remove operation-specific error enums in mm-core
- return `CoreError` from all operations
- clean up unused `#[allow(dead_code)]` attributes
- simplify tool error conversions in mm-server

## Testing
- `just validate`


------
https://chatgpt.com/codex/tasks/task_e_6850c6ed96cc832785b1694a5eb69c23