### PR TITLE
Remove unused CoreError variants

### DIFF
--- a/crates/mm-core/src/error.rs
+++ b/crates/mm-core/src/error.rs
@@ -7,9 +7,6 @@ pub enum CoreError<E>
 where
     E: StdError + Send + Sync + 'static,
 {
-    #[error("Configuration error: {0}")]
-    Config(String),
-
     #[error("Memory error")]
     Memory(#[from] mm_memory::MemoryError<E>),
 
@@ -18,12 +15,6 @@ where
 
     #[error("Validation error")]
     Validation(#[from] mm_memory::ValidationError),
-
-    #[error("Entity not found: {0}")]
-    NotFound(String),
-
-    #[error("MCP error: {0}")]
-    Mcp(String),
 }
 
 /// Result type for mm-core


### PR DESCRIPTION
## Summary
- simplify `CoreError` by dropping unused `Config`, `NotFound`, and `Mcp` variants

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_6850cf1ff0f48327bd56b3df39ed07e7