### PR TITLE
Simplify core operation errors

### DIFF
--- a/crates/mm-core/src/lib.rs
+++ b/crates/mm-core/src/lib.rs
@@ -5,12 +5,10 @@ mod ports;
 pub use error::{CoreError, CoreResult};
 pub use mm_memory::MemoryService;
 pub use operations::{
-    AddObservationsCommand, AddObservationsError, AddObservationsResult, CreateEntityCommand,
-    CreateEntityError, CreateEntityResult, CreateRelationshipCommand, CreateRelationshipError,
-    CreateRelationshipResult, GetEntityCommand, GetEntityError, GetEntityResult,
-    RemoveAllObservationsCommand, RemoveAllObservationsError, RemoveAllObservationsResult,
-    RemoveObservationsCommand, RemoveObservationsError, RemoveObservationsResult,
-    SetObservationsCommand, SetObservationsError, SetObservationsResult, add_observations,
+    AddObservationsCommand, AddObservationsResult, CreateEntityCommand, CreateEntityResult,
+    CreateRelationshipCommand, CreateRelationshipResult, GetEntityCommand, GetEntityResult,
+    RemoveAllObservationsCommand, RemoveAllObservationsResult, RemoveObservationsCommand,
+    RemoveObservationsResult, SetObservationsCommand, SetObservationsResult, add_observations,
     create_entity, create_relationship, get_entity, remove_all_observations, remove_observations,
     set_observations,
 };

--- a/crates/mm-core/src/operations/add_observations.rs
+++ b/crates/mm-core/src/operations/add_observations.rs
@@ -1,7 +1,6 @@
-use crate::error::CoreError;
+use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
-use mm_memory::MemoryRepository;
-use thiserror::Error;
+use mm_memory::{MemoryRepository, ValidationError};
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
@@ -10,21 +9,8 @@ pub struct AddObservationsCommand {
     pub observations: Vec<String>,
 }
 
-#[derive(Debug, Error)]
 #[allow(dead_code)]
-pub enum AddObservationsError<E>
-where
-    E: std::error::Error + Send + Sync + 'static,
-{
-    #[error("Repository error: {0}")]
-    Repository(#[from] CoreError<E>),
-
-    #[error("Validation error: {0}")]
-    Validation(String),
-}
-
-#[allow(dead_code)]
-pub type AddObservationsResult<E> = Result<(), AddObservationsError<E>>;
+pub type AddObservationsResult<E> = CoreResult<(), E>;
 
 #[allow(dead_code)]
 pub async fn add_observations<R>(
@@ -36,9 +22,7 @@ where
     R::Error: std::error::Error + Send + Sync + 'static,
 {
     if command.name.is_empty() {
-        return Err(AddObservationsError::Validation(
-            "Entity name cannot be empty".to_string(),
-        ));
+        return Err(CoreError::Validation(ValidationError::EmptyEntityName));
     }
 
     match ports
@@ -47,7 +31,7 @@ where
         .await
     {
         Ok(_) => Ok(()),
-        Err(e) => Err(AddObservationsError::Repository(CoreError::from(e))),
+        Err(e) => Err(CoreError::from(e)),
     }
 }
 
@@ -84,7 +68,10 @@ mod tests {
             observations: vec![],
         };
         let result = add_observations(&ports, command).await;
-        assert!(matches!(result, Err(AddObservationsError::Validation(_))));
+        assert!(matches!(
+            result,
+            Err(CoreError::Validation(ValidationError::EmptyEntityName))
+        ));
     }
 
     #[tokio::test]
@@ -100,9 +87,6 @@ mod tests {
             observations: vec!["obs".to_string()],
         };
         let result = add_observations(&ports, command).await;
-        assert!(matches!(
-            result,
-            Err(AddObservationsError::Repository(CoreError::Memory(_)))
-        ));
+        assert!(matches!(result, Err(CoreError::Memory(_))));
     }
 }

--- a/crates/mm-core/src/operations/get_entity.rs
+++ b/crates/mm-core/src/operations/get_entity.rs
@@ -1,8 +1,7 @@
 use crate::MemoryEntity;
-use crate::error::CoreError;
+use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
-use mm_memory::MemoryRepository;
-use thiserror::Error;
+use mm_memory::{MemoryRepository, ValidationError};
 
 /// Command to retrieve an entity by name
 #[derive(Debug, Clone)]
@@ -11,20 +10,8 @@ pub struct GetEntityCommand {
 }
 
 /// Error types that can occur when getting an entity
-#[derive(Debug, Error)]
-pub enum GetEntityError<E>
-where
-    E: std::error::Error + Send + Sync + 'static,
-{
-    #[error("Repository error: {0}")]
-    Repository(#[from] CoreError<E>),
-
-    #[error("Validation error: {0}")]
-    Validation(String),
-}
-
 /// Result type for the get_entity operation
-pub type GetEntityResult<E> = Result<Option<MemoryEntity>, GetEntityError<E>>;
+pub type GetEntityResult<E> = CoreResult<Option<MemoryEntity>, E>;
 
 /// Get an entity by name
 ///
@@ -43,9 +30,7 @@ where
 {
     // Validate command
     if command.name.is_empty() {
-        return Err(GetEntityError::Validation(
-            "Entity name cannot be empty".to_string(),
-        ));
+        return Err(CoreError::Validation(ValidationError::EmptyEntityName));
     }
 
     // Find entity using the memory service
@@ -55,7 +40,7 @@ where
         .await
     {
         Ok(entity) => Ok(entity),
-        Err(e) => Err(GetEntityError::Repository(CoreError::from(e))),
+        Err(e) => Err(CoreError::from(e)),
     }
 }
 
@@ -105,7 +90,10 @@ mod tests {
         };
 
         let result = get_entity(&ports, command).await;
-        assert!(matches!(result, Err(GetEntityError::Validation(_))));
+        assert!(matches!(
+            result,
+            Err(CoreError::Validation(ValidationError::EmptyEntityName))
+        ));
     }
 
     #[tokio::test]
@@ -127,9 +115,6 @@ mod tests {
 
         let result = get_entity(&ports, command).await;
 
-        assert!(matches!(
-            result,
-            Err(GetEntityError::Repository(CoreError::Memory(_)))
-        ));
+        assert!(matches!(result, Err(CoreError::Memory(_))));
     }
 }

--- a/crates/mm-core/src/operations/mod.rs
+++ b/crates/mm-core/src/operations/mod.rs
@@ -7,25 +7,16 @@ pub mod remove_all_observations;
 pub mod remove_observations;
 pub mod set_observations;
 
-pub use add_observations::{
-    AddObservationsCommand, AddObservationsError, AddObservationsResult, add_observations,
-};
-pub use create_entity::{
-    CreateEntityCommand, CreateEntityError, CreateEntityResult, create_entity,
-};
+pub use add_observations::{AddObservationsCommand, AddObservationsResult, add_observations};
+pub use create_entity::{CreateEntityCommand, CreateEntityResult, create_entity};
 pub use create_relationship::{
-    CreateRelationshipCommand, CreateRelationshipError, CreateRelationshipResult,
-    create_relationship,
+    CreateRelationshipCommand, CreateRelationshipResult, create_relationship,
 };
-pub use get_entity::{GetEntityCommand, GetEntityError, GetEntityResult, get_entity};
+pub use get_entity::{GetEntityCommand, GetEntityResult, get_entity};
 pub use remove_all_observations::{
-    RemoveAllObservationsCommand, RemoveAllObservationsError, RemoveAllObservationsResult,
-    remove_all_observations,
+    RemoveAllObservationsCommand, RemoveAllObservationsResult, remove_all_observations,
 };
 pub use remove_observations::{
-    RemoveObservationsCommand, RemoveObservationsError, RemoveObservationsResult,
-    remove_observations,
+    RemoveObservationsCommand, RemoveObservationsResult, remove_observations,
 };
-pub use set_observations::{
-    SetObservationsCommand, SetObservationsError, SetObservationsResult, set_observations,
-};
+pub use set_observations::{SetObservationsCommand, SetObservationsResult, set_observations};

--- a/crates/mm-core/src/operations/remove_all_observations.rs
+++ b/crates/mm-core/src/operations/remove_all_observations.rs
@@ -1,7 +1,6 @@
-use crate::error::CoreError;
+use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
-use mm_memory::MemoryRepository;
-use thiserror::Error;
+use mm_memory::{MemoryRepository, ValidationError};
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
@@ -9,21 +8,8 @@ pub struct RemoveAllObservationsCommand {
     pub name: String,
 }
 
-#[derive(Debug, Error)]
 #[allow(dead_code)]
-pub enum RemoveAllObservationsError<E>
-where
-    E: std::error::Error + Send + Sync + 'static,
-{
-    #[error("Repository error: {0}")]
-    Repository(#[from] CoreError<E>),
-
-    #[error("Validation error: {0}")]
-    Validation(String),
-}
-
-#[allow(dead_code)]
-pub type RemoveAllObservationsResult<E> = Result<(), RemoveAllObservationsError<E>>;
+pub type RemoveAllObservationsResult<E> = CoreResult<(), E>;
 
 #[allow(dead_code)]
 pub async fn remove_all_observations<R>(
@@ -35,9 +21,7 @@ where
     R::Error: std::error::Error + Send + Sync + 'static,
 {
     if command.name.is_empty() {
-        return Err(RemoveAllObservationsError::Validation(
-            "Entity name cannot be empty".to_string(),
-        ));
+        return Err(CoreError::Validation(ValidationError::EmptyEntityName));
     }
 
     match ports
@@ -46,7 +30,7 @@ where
         .await
     {
         Ok(_) => Ok(()),
-        Err(e) => Err(RemoveAllObservationsError::Repository(CoreError::from(e))),
+        Err(e) => Err(CoreError::from(e)),
     }
 }
 
@@ -83,7 +67,7 @@ mod tests {
         let result = remove_all_observations(&ports, command).await;
         assert!(matches!(
             result,
-            Err(RemoveAllObservationsError::Validation(_))
+            Err(CoreError::Validation(ValidationError::EmptyEntityName))
         ));
     }
 
@@ -99,9 +83,6 @@ mod tests {
             name: "test:entity".to_string(),
         };
         let result = remove_all_observations(&ports, command).await;
-        assert!(matches!(
-            result,
-            Err(RemoveAllObservationsError::Repository(CoreError::Memory(_)))
-        ));
+        assert!(matches!(result, Err(CoreError::Memory(_))));
     }
 }

--- a/crates/mm-server/src/mcp/error.rs
+++ b/crates/mm-server/src/mcp/error.rs
@@ -1,8 +1,5 @@
 use mm_core::CoreError;
-use mm_core::{
-    AddObservationsError, CreateEntityError, CreateRelationshipError, GetEntityError,
-    RemoveAllObservationsError, RemoveObservationsError, SetObservationsError,
-};
+
 use rust_mcp_sdk::schema::schema_utils::CallToolError;
 use std::error::Error as StdError;
 use std::fmt;
@@ -49,72 +46,6 @@ where
 {
     fn from(error: CoreError<E>) -> Self {
         Self::with_source(format!("{:#?}", error), error)
-    }
-}
-
-impl<E> From<CreateEntityError<E>> for ToolError
-where
-    E: StdError + Send + Sync + 'static,
-{
-    fn from(error: CreateEntityError<E>) -> Self {
-        Self::with_source(format!("Create entity error: {:#?}", error), error)
-    }
-}
-
-impl<E> From<GetEntityError<E>> for ToolError
-where
-    E: StdError + Send + Sync + 'static,
-{
-    fn from(error: GetEntityError<E>) -> Self {
-        Self::with_source(format!("Get entity error: {:#?}", error), error)
-    }
-}
-
-impl<E> From<SetObservationsError<E>> for ToolError
-where
-    E: StdError + Send + Sync + 'static,
-{
-    fn from(error: SetObservationsError<E>) -> Self {
-        Self::with_source(format!("Set observations error: {:#?}", error), error)
-    }
-}
-
-impl<E> From<AddObservationsError<E>> for ToolError
-where
-    E: StdError + Send + Sync + 'static,
-{
-    fn from(error: AddObservationsError<E>) -> Self {
-        Self::with_source(format!("Add observations error: {:#?}", error), error)
-    }
-}
-
-impl<E> From<RemoveAllObservationsError<E>> for ToolError
-where
-    E: StdError + Send + Sync + 'static,
-{
-    fn from(error: RemoveAllObservationsError<E>) -> Self {
-        Self::with_source(
-            format!("Remove all observations error: {:#?}", error),
-            error,
-        )
-    }
-}
-
-impl<E> From<RemoveObservationsError<E>> for ToolError
-where
-    E: StdError + Send + Sync + 'static,
-{
-    fn from(error: RemoveObservationsError<E>) -> Self {
-        Self::with_source(format!("Remove observations error: {:#?}", error), error)
-    }
-}
-
-impl<E> From<CreateRelationshipError<E>> for ToolError
-where
-    E: StdError + Send + Sync + 'static,
-{
-    fn from(error: CreateRelationshipError<E>) -> Self {
-        Self::with_source(format!("Create relationship error: {:#?}", error), error)
     }
 }
 


### PR DESCRIPTION
## Summary
- remove custom operation error enums and use `CoreError` directly
- propagate `mm_memory::ValidationError` from operations
- streamline MCP tool error conversions

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_6850cf0fb0e88327987880dabec271de