### PR TITLE
Improve ToolError messaging

### DIFF
--- a/crates/mm-server/src/mcp/error.rs
+++ b/crates/mm-server/src/mcp/error.rs
@@ -45,7 +45,12 @@ where
     E: StdError + Send + Sync + 'static,
 {
     fn from(error: CoreError<E>) -> Self {
-        Self::with_source(format!("{:#?}", error), error)
+        let message = match &error {
+            CoreError::Memory(e) => e.to_string(),
+            CoreError::Serialization(e) => e.to_string(),
+            CoreError::Validation(e) => e.to_string(),
+        };
+        Self::with_source(message, error)
     }
 }
 


### PR DESCRIPTION
## Summary
- show CoreError message using Display instead of Debug when mapping to ToolError

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_6850d422ea4c8327b9238cdb4016abb1