### PR TITLE
Simplify memory service calls

### DIFF
--- a/crates/mm-core/src/operations/add_observations.rs
+++ b/crates/mm-core/src/operations/add_observations.rs
@@ -25,14 +25,11 @@ where
         return Err(CoreError::Validation(ValidationError::EmptyEntityName));
     }
 
-    match ports
+    ports
         .memory_service
         .add_observations(&command.name, &command.observations)
         .await
-    {
-        Ok(_) => Ok(()),
-        Err(e) => Err(CoreError::from(e)),
-    }
+        .map_err(CoreError::from)
 }
 
 #[cfg(test)]

--- a/crates/mm-core/src/operations/create_entity.rs
+++ b/crates/mm-core/src/operations/create_entity.rs
@@ -53,10 +53,11 @@ where
         properties: command.properties,
     };
 
-    match ports.memory_service.create_entity(&entity).await {
-        Ok(_) => Ok(()),
-        Err(e) => Err(CoreError::from(e)),
-    }
+    ports
+        .memory_service
+        .create_entity(&entity)
+        .await
+        .map_err(CoreError::from)
 }
 
 #[cfg(test)]

--- a/crates/mm-core/src/operations/create_relationship.rs
+++ b/crates/mm-core/src/operations/create_relationship.rs
@@ -28,10 +28,11 @@ where
         properties: command.properties,
     };
 
-    match ports.memory_service.create_relationship(&rel).await {
-        Ok(_) => Ok(()),
-        Err(e) => Err(CoreError::from(e)),
-    }
+    ports
+        .memory_service
+        .create_relationship(&rel)
+        .await
+        .map_err(CoreError::from)
 }
 
 #[cfg(test)]

--- a/crates/mm-core/src/operations/get_entity.rs
+++ b/crates/mm-core/src/operations/get_entity.rs
@@ -34,14 +34,11 @@ where
     }
 
     // Find entity using the memory service
-    match ports
+    ports
         .memory_service
         .find_entity_by_name(&command.name)
         .await
-    {
-        Ok(entity) => Ok(entity),
-        Err(e) => Err(CoreError::from(e)),
-    }
+        .map_err(CoreError::from)
 }
 
 #[cfg(test)]

--- a/crates/mm-core/src/operations/remove_all_observations.rs
+++ b/crates/mm-core/src/operations/remove_all_observations.rs
@@ -24,14 +24,11 @@ where
         return Err(CoreError::Validation(ValidationError::EmptyEntityName));
     }
 
-    match ports
+    ports
         .memory_service
         .remove_all_observations(&command.name)
         .await
-    {
-        Ok(_) => Ok(()),
-        Err(e) => Err(CoreError::from(e)),
-    }
+        .map_err(CoreError::from)
 }
 
 #[cfg(test)]

--- a/crates/mm-core/src/operations/remove_observations.rs
+++ b/crates/mm-core/src/operations/remove_observations.rs
@@ -25,14 +25,11 @@ where
         return Err(CoreError::Validation(ValidationError::EmptyEntityName));
     }
 
-    match ports
+    ports
         .memory_service
         .remove_observations(&command.name, &command.observations)
         .await
-    {
-        Ok(_) => Ok(()),
-        Err(e) => Err(CoreError::from(e)),
-    }
+        .map_err(CoreError::from)
 }
 
 #[cfg(test)]

--- a/crates/mm-core/src/operations/set_observations.rs
+++ b/crates/mm-core/src/operations/set_observations.rs
@@ -25,14 +25,11 @@ where
         return Err(CoreError::Validation(ValidationError::EmptyEntityName));
     }
 
-    match ports
+    ports
         .memory_service
         .set_observations(&command.name, &command.observations)
         .await
-    {
-        Ok(_) => Ok(()),
-        Err(e) => Err(CoreError::from(e)),
-    }
+        .map_err(CoreError::from)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- refactor mm-core operations to use `map_err(CoreError::from)` when calling memory service

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_6850d41904dc83279cf2287116004055