### PR TITLE
Collect multiple validation errors

### DIFF
--- a/crates/mm-memory/src/validation_error.rs
+++ b/crates/mm-memory/src/validation_error.rs
@@ -18,4 +18,8 @@ pub enum ValidationError {
     /// Error when a relationship type is not allowed
     #[error("Relationship type '{0}' is not allowed")]
     UnknownRelationship(String),
+
+    /// Multiple validation errors occurred
+    #[error("Multiple validation errors")]
+    Multiple(Vec<ValidationError>),
 }


### PR DESCRIPTION
## Summary
- gather validation errors in `MemoryService`
- add `Multiple` variant to `ValidationError`
- test returning multiple validation errors

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_6850db72163c8327b65b9b4739621c8c