### PR TITLE
Add aggregated validation error support

### DIFF
--- a/crates/mm-core/src/operations/add_observations.rs
+++ b/crates/mm-core/src/operations/add_observations.rs
@@ -1,6 +1,6 @@
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
-use mm_memory::{MemoryRepository, ValidationError};
+use mm_memory::{MemoryRepository, ValidationError, ValidationErrorKind};
 
 #[derive(Debug, Clone)]
 pub struct AddObservationsCommand {
@@ -19,7 +19,9 @@ where
     R::Error: std::error::Error + Send + Sync + 'static,
 {
     if command.name.is_empty() {
-        return Err(CoreError::Validation(ValidationError::EmptyEntityName));
+        return Err(CoreError::Validation(ValidationError(vec![
+            ValidationErrorKind::EmptyEntityName,
+        ])));
     }
 
     ports
@@ -64,7 +66,7 @@ mod tests {
         let result = add_observations(&ports, command).await;
         assert!(matches!(
             result,
-            Err(CoreError::Validation(ValidationError::EmptyEntityName))
+            Err(CoreError::Validation(ref e)) if e.0.contains(&ValidationErrorKind::EmptyEntityName)
         ));
     }
 

--- a/crates/mm-core/src/operations/create_entity.rs
+++ b/crates/mm-core/src/operations/create_entity.rs
@@ -1,7 +1,7 @@
 use crate::MemoryEntity;
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
-use mm_memory::{MemoryRepository, ValidationError};
+use mm_memory::{MemoryRepository, ValidationError, ValidationErrorKind};
 use std::collections::HashMap;
 
 /// Command to create a new entity
@@ -36,13 +36,15 @@ where
 {
     // Validate command
     if command.name.is_empty() {
-        return Err(CoreError::Validation(ValidationError::EmptyEntityName));
+        return Err(CoreError::Validation(ValidationError(vec![
+            ValidationErrorKind::EmptyEntityName,
+        ])));
     }
 
     if command.labels.is_empty() {
-        return Err(CoreError::Validation(ValidationError::NoLabels(
-            command.name.clone(),
-        )));
+        return Err(CoreError::Validation(ValidationError(vec![
+            ValidationErrorKind::NoLabels(command.name.clone()),
+        ])));
     }
 
     // Create entity using the memory service
@@ -106,7 +108,7 @@ mod tests {
         let result = create_entity(&ports, command).await;
         assert!(matches!(
             result,
-            Err(CoreError::Validation(ValidationError::EmptyEntityName))
+            Err(CoreError::Validation(ref e)) if e.0.contains(&ValidationErrorKind::EmptyEntityName)
         ));
     }
 

--- a/crates/mm-core/src/operations/create_relationship.rs
+++ b/crates/mm-core/src/operations/create_relationship.rs
@@ -95,9 +95,8 @@ mod tests {
         let result = create_relationship(&ports, command).await;
         assert!(matches!(
             result,
-            Err(CoreError::Memory(mm_memory::MemoryError::ValidationError(
-                mm_memory::ValidationError::InvalidRelationshipFormat(_)
-            )))
+            Err(CoreError::Memory(mm_memory::MemoryError::ValidationError(ref e)))
+                if e.0.contains(&mm_memory::ValidationErrorKind::InvalidRelationshipFormat("InvalidFormat".to_string()))
         ));
     }
 
@@ -118,9 +117,8 @@ mod tests {
         let result = create_relationship(&ports, command).await;
         assert!(matches!(
             result,
-            Err(CoreError::Memory(mm_memory::MemoryError::ValidationError(
-                mm_memory::ValidationError::UnknownRelationship(_)
-            )))
+            Err(CoreError::Memory(mm_memory::MemoryError::ValidationError(ref e)))
+                if e.0.contains(&mm_memory::ValidationErrorKind::UnknownRelationship("custom_rel".to_string()))
         ));
     }
 }

--- a/crates/mm-core/src/operations/get_entity.rs
+++ b/crates/mm-core/src/operations/get_entity.rs
@@ -1,7 +1,7 @@
 use crate::MemoryEntity;
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
-use mm_memory::{MemoryRepository, ValidationError};
+use mm_memory::{MemoryRepository, ValidationError, ValidationErrorKind};
 
 /// Command to retrieve an entity by name
 #[derive(Debug, Clone)]
@@ -30,7 +30,9 @@ where
 {
     // Validate command
     if command.name.is_empty() {
-        return Err(CoreError::Validation(ValidationError::EmptyEntityName));
+        return Err(CoreError::Validation(ValidationError(vec![
+            ValidationErrorKind::EmptyEntityName,
+        ])));
     }
 
     // Find entity using the memory service
@@ -89,7 +91,7 @@ mod tests {
         let result = get_entity(&ports, command).await;
         assert!(matches!(
             result,
-            Err(CoreError::Validation(ValidationError::EmptyEntityName))
+            Err(CoreError::Validation(ref e)) if e.0.contains(&ValidationErrorKind::EmptyEntityName)
         ));
     }
 

--- a/crates/mm-core/src/operations/remove_all_observations.rs
+++ b/crates/mm-core/src/operations/remove_all_observations.rs
@@ -1,6 +1,6 @@
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
-use mm_memory::{MemoryRepository, ValidationError};
+use mm_memory::{MemoryRepository, ValidationError, ValidationErrorKind};
 
 #[derive(Debug, Clone)]
 pub struct RemoveAllObservationsCommand {
@@ -18,7 +18,9 @@ where
     R::Error: std::error::Error + Send + Sync + 'static,
 {
     if command.name.is_empty() {
-        return Err(CoreError::Validation(ValidationError::EmptyEntityName));
+        return Err(CoreError::Validation(ValidationError(vec![
+            ValidationErrorKind::EmptyEntityName,
+        ])));
     }
 
     ports
@@ -61,7 +63,7 @@ mod tests {
         let result = remove_all_observations(&ports, command).await;
         assert!(matches!(
             result,
-            Err(CoreError::Validation(ValidationError::EmptyEntityName))
+            Err(CoreError::Validation(ref e)) if e.0.contains(&ValidationErrorKind::EmptyEntityName)
         ));
     }
 

--- a/crates/mm-core/src/operations/remove_observations.rs
+++ b/crates/mm-core/src/operations/remove_observations.rs
@@ -1,6 +1,6 @@
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
-use mm_memory::{MemoryRepository, ValidationError};
+use mm_memory::{MemoryRepository, ValidationError, ValidationErrorKind};
 
 #[derive(Debug, Clone)]
 pub struct RemoveObservationsCommand {
@@ -19,7 +19,9 @@ where
     R::Error: std::error::Error + Send + Sync + 'static,
 {
     if command.name.is_empty() {
-        return Err(CoreError::Validation(ValidationError::EmptyEntityName));
+        return Err(CoreError::Validation(ValidationError(vec![
+            ValidationErrorKind::EmptyEntityName,
+        ])));
     }
 
     ports
@@ -64,7 +66,7 @@ mod tests {
         let result = remove_observations(&ports, command).await;
         assert!(matches!(
             result,
-            Err(CoreError::Validation(ValidationError::EmptyEntityName))
+            Err(CoreError::Validation(ref e)) if e.0.contains(&ValidationErrorKind::EmptyEntityName)
         ));
     }
 

--- a/crates/mm-core/src/operations/set_observations.rs
+++ b/crates/mm-core/src/operations/set_observations.rs
@@ -1,6 +1,6 @@
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
-use mm_memory::{MemoryRepository, ValidationError};
+use mm_memory::{MemoryRepository, ValidationError, ValidationErrorKind};
 
 #[derive(Debug, Clone)]
 pub struct SetObservationsCommand {
@@ -19,7 +19,9 @@ where
     R::Error: std::error::Error + Send + Sync + 'static,
 {
     if command.name.is_empty() {
-        return Err(CoreError::Validation(ValidationError::EmptyEntityName));
+        return Err(CoreError::Validation(ValidationError(vec![
+            ValidationErrorKind::EmptyEntityName,
+        ])));
     }
 
     ports
@@ -64,7 +66,7 @@ mod tests {
         let result = set_observations(&ports, command).await;
         assert!(matches!(
             result,
-            Err(CoreError::Validation(ValidationError::EmptyEntityName))
+            Err(CoreError::Validation(ref e)) if e.0.contains(&ValidationErrorKind::EmptyEntityName)
         ));
     }
 

--- a/crates/mm-memory-neo4j/src/adapters/neo4j.rs
+++ b/crates/mm-memory-neo4j/src/adapters/neo4j.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 
 use mm_memory::{
     MemoryEntity, MemoryError, MemoryRelationship, MemoryRepository, MemoryResult, ValidationError,
+    ValidationErrorKind,
 };
 
 /// Configuration for connecting to Neo4j
@@ -66,11 +67,13 @@ impl MemoryRepository for Neo4jRepository {
     async fn create_entity(&self, entity: &MemoryEntity) -> MemoryResult<(), Self::Error> {
         // Validate entity
         if entity.name.is_empty() {
-            return Err(ValidationError::EmptyEntityName.into());
+            return Err(ValidationError::from(ValidationErrorKind::EmptyEntityName).into());
         }
 
         if entity.labels.is_empty() {
-            return Err(ValidationError::NoLabels(entity.name.clone()).into());
+            return Err(
+                ValidationError::from(ValidationErrorKind::NoLabels(entity.name.clone())).into(),
+            );
         }
 
         let labels = entity.labels.join(":");
@@ -108,7 +111,7 @@ impl MemoryRepository for Neo4jRepository {
     ) -> MemoryResult<Option<MemoryEntity>, Self::Error> {
         // Validate name
         if name.is_empty() {
-            return Err(ValidationError::EmptyEntityName.into());
+            return Err(ValidationError::from(ValidationErrorKind::EmptyEntityName).into());
         }
 
         let query = Query::new("MATCH (n {name: $name}) RETURN n".to_string())
@@ -193,7 +196,7 @@ impl MemoryRepository for Neo4jRepository {
         observations: &[String],
     ) -> MemoryResult<(), Self::Error> {
         if name.is_empty() {
-            return Err(ValidationError::EmptyEntityName.into());
+            return Err(ValidationError::from(ValidationErrorKind::EmptyEntityName).into());
         }
 
         let observations_json = serde_json::to_string(observations)?;

--- a/crates/mm-memory/src/lib.rs
+++ b/crates/mm-memory/src/lib.rs
@@ -15,4 +15,4 @@ pub use repository::MemoryRepository;
 #[cfg(any(test, feature = "mock"))]
 pub use repository::MockMemoryRepository;
 pub use service::MemoryService;
-pub use validation_error::ValidationError;
+pub use validation_error::{ValidationError, ValidationErrorKind};

--- a/crates/mm-memory/src/validation_error.rs
+++ b/crates/mm-memory/src/validation_error.rs
@@ -1,8 +1,8 @@
 use thiserror::Error;
 
-/// Validation errors for memory operations
+/// Individual validation error types
 #[derive(Error, Debug, Clone, PartialEq)]
-pub enum ValidationError {
+pub enum ValidationErrorKind {
     /// Error when an entity name is empty
     #[error("Entity name cannot be empty")]
     EmptyEntityName,
@@ -18,4 +18,23 @@ pub enum ValidationError {
     /// Error when a relationship type is not allowed
     #[error("Relationship type '{0}' is not allowed")]
     UnknownRelationship(String),
+}
+
+/// Collection of validation errors
+#[derive(Debug, Clone, PartialEq)]
+pub struct ValidationError(pub Vec<ValidationErrorKind>);
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let msgs: Vec<String> = self.0.iter().map(|e| e.to_string()).collect();
+        write!(f, "{}", msgs.join("; "))
+    }
+}
+
+impl std::error::Error for ValidationError {}
+
+impl From<ValidationErrorKind> for ValidationError {
+    fn from(kind: ValidationErrorKind) -> Self {
+        Self(vec![kind])
+    }
 }


### PR DESCRIPTION
## Summary
- allow `ValidationError` to hold multiple `ValidationErrorKind`s
- aggregate checks in `MemoryService`
- adjust Neo4j adapter and core operations for new error type
- update tests for aggregated validation errors

## Testing
- `cargo check`
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_6850dd41ebc48327bbda38b4e4d723ad