### PR TITLE
Add macro to generate MCP call_tool functions

### DIFF
--- a/crates/mm-server/src/mcp/add_observations.rs
+++ b/crates/mm-server/src/mcp/add_observations.rs
@@ -1,4 +1,3 @@
-use crate::generate_call_tool;
 use mm_core::{AddObservationsCommand, add_observations};
 use rust_mcp_sdk::macros::{JsonSchema, mcp_tool};
 use serde::{Deserialize, Serialize};

--- a/crates/mm-server/src/mcp/create_entity.rs
+++ b/crates/mm-server/src/mcp/create_entity.rs
@@ -1,4 +1,3 @@
-use crate::generate_call_tool;
 use mm_core::{CreateEntityCommand, create_entity};
 use rust_mcp_sdk::macros::{JsonSchema, mcp_tool};
 use serde::{Deserialize, Serialize};

--- a/crates/mm-server/src/mcp/create_relationship.rs
+++ b/crates/mm-server/src/mcp/create_relationship.rs
@@ -1,4 +1,3 @@
-use crate::generate_call_tool;
 use mm_core::{CreateRelationshipCommand, create_relationship};
 use rust_mcp_sdk::macros::{JsonSchema, mcp_tool};
 use serde::{Deserialize, Serialize};

--- a/crates/mm-server/src/mcp/get_entity.rs
+++ b/crates/mm-server/src/mcp/get_entity.rs
@@ -1,4 +1,3 @@
-use crate::generate_call_tool;
 use mm_core::{GetEntityCommand, get_entity};
 use rust_mcp_sdk::macros::{JsonSchema, mcp_tool};
 use serde::{Deserialize, Serialize};

--- a/crates/mm-server/src/mcp/macros.rs
+++ b/crates/mm-server/src/mcp/macros.rs
@@ -1,4 +1,3 @@
-#[macro_export]
 macro_rules! generate_call_tool {
     (@value $self_field:expr $(, $value:expr)? ) => {
         generate_call_tool!(@inner $self_field $(, $value)? )

--- a/crates/mm-server/src/mcp/mod.rs
+++ b/crates/mm-server/src/mcp/mod.rs
@@ -1,9 +1,10 @@
+#[macro_use]
+mod macros;
 pub mod add_observations;
 pub mod create_entity;
 pub mod create_relationship;
 pub mod error;
 pub mod get_entity;
-pub mod macros;
 pub mod remove_all_observations;
 pub mod remove_observations;
 pub mod set_observations;

--- a/crates/mm-server/src/mcp/remove_all_observations.rs
+++ b/crates/mm-server/src/mcp/remove_all_observations.rs
@@ -1,4 +1,3 @@
-use crate::generate_call_tool;
 use mm_core::{RemoveAllObservationsCommand, remove_all_observations};
 use rust_mcp_sdk::macros::{JsonSchema, mcp_tool};
 use serde::{Deserialize, Serialize};

--- a/crates/mm-server/src/mcp/remove_observations.rs
+++ b/crates/mm-server/src/mcp/remove_observations.rs
@@ -1,4 +1,3 @@
-use crate::generate_call_tool;
 use mm_core::{RemoveObservationsCommand, remove_observations};
 use rust_mcp_sdk::macros::{JsonSchema, mcp_tool};
 use serde::{Deserialize, Serialize};

--- a/crates/mm-server/src/mcp/set_observations.rs
+++ b/crates/mm-server/src/mcp/set_observations.rs
@@ -1,4 +1,3 @@
-use crate::generate_call_tool;
 use mm_core::{SetObservationsCommand, set_observations};
 use rust_mcp_sdk::macros::{JsonSchema, mcp_tool};
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
## Summary
- add `generate_call_tool!` macro for common tool implementations
- refactor all memory tools to use the new macro
- `CreateEntityTool` now returns entity JSON again

## Testing
- `just validate`


------
https://chatgpt.com/codex/tasks/task_e_6850e3b4dcc0832795bd76a30092901a