### PR TITLE
Add reusable entity name validation macro

### DIFF
--- a/crates/mm-core/src/operations/add_observations.rs
+++ b/crates/mm-core/src/operations/add_observations.rs
@@ -1,6 +1,7 @@
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
-use mm_memory::{MemoryRepository, ValidationError, ValidationErrorKind};
+use crate::validate_name;
+use mm_memory::MemoryRepository;
 
 #[derive(Debug, Clone)]
 pub struct AddObservationsCommand {
@@ -18,11 +19,7 @@ where
     R: MemoryRepository + Send + Sync,
     R::Error: std::error::Error + Send + Sync + 'static,
 {
-    if command.name.is_empty() {
-        return Err(CoreError::Validation(ValidationError(vec![
-            ValidationErrorKind::EmptyEntityName,
-        ])));
-    }
+    validate_name!(command.name);
 
     ports
         .memory_service
@@ -34,7 +31,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mm_memory::{MemoryConfig, MemoryError, MemoryService, MockMemoryRepository};
+    use mm_memory::{
+        MemoryConfig, MemoryError, MemoryService, MockMemoryRepository, ValidationErrorKind,
+    };
     use std::sync::Arc;
 
     #[tokio::test]

--- a/crates/mm-core/src/operations/common.rs
+++ b/crates/mm-core/src/operations/common.rs
@@ -1,0 +1,10 @@
+#[macro_export]
+macro_rules! validate_name {
+    ($name:expr) => {
+        if $name.is_empty() {
+            return Err($crate::error::CoreError::Validation(
+                mm_memory::ValidationError(vec![mm_memory::ValidationErrorKind::EmptyEntityName]),
+            ));
+        }
+    };
+}

--- a/crates/mm-core/src/operations/create_entity.rs
+++ b/crates/mm-core/src/operations/create_entity.rs
@@ -1,6 +1,7 @@
 use crate::MemoryEntity;
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
+use crate::validate_name;
 use mm_memory::{MemoryRepository, ValidationError, ValidationErrorKind};
 use std::collections::HashMap;
 
@@ -35,11 +36,7 @@ where
     R::Error: std::error::Error + Send + Sync + 'static,
 {
     // Validate command
-    if command.name.is_empty() {
-        return Err(CoreError::Validation(ValidationError(vec![
-            ValidationErrorKind::EmptyEntityName,
-        ])));
-    }
+    validate_name!(command.name);
 
     if command.labels.is_empty() {
         return Err(CoreError::Validation(ValidationError(vec![

--- a/crates/mm-core/src/operations/get_entity.rs
+++ b/crates/mm-core/src/operations/get_entity.rs
@@ -1,7 +1,8 @@
 use crate::MemoryEntity;
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
-use mm_memory::{MemoryRepository, ValidationError, ValidationErrorKind};
+use crate::validate_name;
+use mm_memory::MemoryRepository;
 
 /// Command to retrieve an entity by name
 #[derive(Debug, Clone)]
@@ -29,11 +30,7 @@ where
     R::Error: std::error::Error + Send + Sync + 'static,
 {
     // Validate command
-    if command.name.is_empty() {
-        return Err(CoreError::Validation(ValidationError(vec![
-            ValidationErrorKind::EmptyEntityName,
-        ])));
-    }
+    validate_name!(command.name);
 
     // Find entity using the memory service
     ports
@@ -46,7 +43,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
+    use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository, ValidationErrorKind};
     use mockall::predicate::*;
     use std::collections::HashMap;
     use std::sync::Arc;

--- a/crates/mm-core/src/operations/mod.rs
+++ b/crates/mm-core/src/operations/mod.rs
@@ -1,3 +1,5 @@
+mod common;
+
 pub mod add_observations;
 pub mod create_entity;
 pub mod create_relationship;

--- a/crates/mm-core/src/operations/remove_all_observations.rs
+++ b/crates/mm-core/src/operations/remove_all_observations.rs
@@ -1,6 +1,7 @@
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
-use mm_memory::{MemoryRepository, ValidationError, ValidationErrorKind};
+use crate::validate_name;
+use mm_memory::MemoryRepository;
 
 #[derive(Debug, Clone)]
 pub struct RemoveAllObservationsCommand {
@@ -17,11 +18,7 @@ where
     R: MemoryRepository + Send + Sync,
     R::Error: std::error::Error + Send + Sync + 'static,
 {
-    if command.name.is_empty() {
-        return Err(CoreError::Validation(ValidationError(vec![
-            ValidationErrorKind::EmptyEntityName,
-        ])));
-    }
+    validate_name!(command.name);
 
     ports
         .memory_service
@@ -33,7 +30,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mm_memory::{MemoryConfig, MemoryError, MemoryService, MockMemoryRepository};
+    use mm_memory::{
+        MemoryConfig, MemoryError, MemoryService, MockMemoryRepository, ValidationErrorKind,
+    };
     use std::sync::Arc;
 
     #[tokio::test]

--- a/crates/mm-core/src/operations/remove_observations.rs
+++ b/crates/mm-core/src/operations/remove_observations.rs
@@ -1,6 +1,7 @@
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
-use mm_memory::{MemoryRepository, ValidationError, ValidationErrorKind};
+use crate::validate_name;
+use mm_memory::MemoryRepository;
 
 #[derive(Debug, Clone)]
 pub struct RemoveObservationsCommand {
@@ -18,11 +19,7 @@ where
     R: MemoryRepository + Send + Sync,
     R::Error: std::error::Error + Send + Sync + 'static,
 {
-    if command.name.is_empty() {
-        return Err(CoreError::Validation(ValidationError(vec![
-            ValidationErrorKind::EmptyEntityName,
-        ])));
-    }
+    validate_name!(command.name);
 
     ports
         .memory_service
@@ -34,7 +31,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mm_memory::{MemoryConfig, MemoryError, MemoryService, MockMemoryRepository};
+    use mm_memory::{
+        MemoryConfig, MemoryError, MemoryService, MockMemoryRepository, ValidationErrorKind,
+    };
     use std::sync::Arc;
 
     #[tokio::test]

--- a/crates/mm-core/src/operations/set_observations.rs
+++ b/crates/mm-core/src/operations/set_observations.rs
@@ -1,6 +1,7 @@
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
-use mm_memory::{MemoryRepository, ValidationError, ValidationErrorKind};
+use crate::validate_name;
+use mm_memory::MemoryRepository;
 
 #[derive(Debug, Clone)]
 pub struct SetObservationsCommand {
@@ -18,11 +19,7 @@ where
     R: MemoryRepository + Send + Sync,
     R::Error: std::error::Error + Send + Sync + 'static,
 {
-    if command.name.is_empty() {
-        return Err(CoreError::Validation(ValidationError(vec![
-            ValidationErrorKind::EmptyEntityName,
-        ])));
-    }
+    validate_name!(command.name);
 
     ports
         .memory_service
@@ -34,7 +31,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mm_memory::{MemoryConfig, MemoryError, MemoryService, MockMemoryRepository};
+    use mm_memory::{
+        MemoryConfig, MemoryError, MemoryService, MockMemoryRepository, ValidationErrorKind,
+    };
     use std::sync::Arc;
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- create `validate_name!` macro for entity name validation
- remove legacy `#[macro_use]` import and explicitly use the macro
- update operations to rely on the helper and adjust unit tests

## Testing
- `just validate`


------
https://chatgpt.com/codex/tasks/task_e_6850e4da1fd48327807ee51808be38be