### PR TITLE
Drop single-item memory repository methods

### DIFF
--- a/crates/mm-memory-neo4j/src/adapters/neo4j.rs
+++ b/crates/mm-memory-neo4j/src/adapters/neo4j.rs
@@ -97,9 +97,6 @@ impl MemoryRepository for Neo4jRepository {
 
         Ok(())
     }
-    async fn create_entity(&self, entity: &MemoryEntity) -> MemoryResult<(), Self::Error> {
-        self.create_entities(std::slice::from_ref(entity)).await
-    }
 
     async fn find_entity_by_name(
         &self,
@@ -275,13 +272,5 @@ impl MemoryRepository for Neo4jRepository {
         })?;
 
         Ok(())
-    }
-
-    async fn create_relationship(
-        &self,
-        relationship: &MemoryRelationship,
-    ) -> MemoryResult<(), Self::Error> {
-        self.create_relationships(std::slice::from_ref(relationship))
-            .await
     }
 }

--- a/crates/mm-memory-neo4j/tests/neo4j_integration.rs
+++ b/crates/mm-memory-neo4j/tests/neo4j_integration.rs
@@ -69,7 +69,10 @@ async fn test_create_and_find_entity() {
     };
 
     // Test that entity creation doesn't error
-    service.create_entity(&entity).await.unwrap();
+    service
+        .create_entities(std::slice::from_ref(&entity))
+        .await
+        .unwrap();
 
     // Test that we can find the entity after creation
     let found = service
@@ -118,7 +121,7 @@ async fn test_validation_errors() {
         properties: HashMap::new(),
     };
 
-    let result = service.create_entity(&entity).await;
+    let result = service.create_entities(std::slice::from_ref(&entity)).await;
     assert!(result.is_ok());
 
     // Ensure the default tag was applied
@@ -157,7 +160,10 @@ async fn test_set_observations() {
         properties: HashMap::new(),
     };
 
-    service.create_entity(&entity).await.unwrap();
+    service
+        .create_entities(std::slice::from_ref(&entity))
+        .await
+        .unwrap();
 
     service
         .set_observations(entity_name, &["replaced".to_string()])
@@ -199,7 +205,10 @@ async fn test_add_and_remove_observations() {
         properties: HashMap::new(),
     };
 
-    service.create_entity(&entity).await.unwrap();
+    service
+        .create_entities(std::slice::from_ref(&entity))
+        .await
+        .unwrap();
 
     service
         .add_observations(entity_name, &["obs3".to_string()])
@@ -267,8 +276,14 @@ async fn test_create_relationship() {
         properties: HashMap::new(),
     };
 
-    service.create_entity(&a).await.unwrap();
-    service.create_entity(&b).await.unwrap();
+    service
+        .create_entities(std::slice::from_ref(&a))
+        .await
+        .unwrap();
+    service
+        .create_entities(std::slice::from_ref(&b))
+        .await
+        .unwrap();
 
     let rel = MemoryRelationship {
         from: a.name.clone(),
@@ -277,5 +292,8 @@ async fn test_create_relationship() {
         properties: HashMap::new(),
     };
 
-    service.create_relationship(&rel).await.unwrap();
+    service
+        .create_relationships(std::slice::from_ref(&rel))
+        .await
+        .unwrap();
 }

--- a/crates/mm-memory/src/repository.rs
+++ b/crates/mm-memory/src/repository.rs
@@ -10,14 +10,7 @@ use crate::relationship::MemoryRelationship;
 pub trait MemoryRepository {
     type Error: StdError + Send + Sync + 'static;
 
-    async fn create_entities(&self, entities: &[MemoryEntity]) -> MemoryResult<(), Self::Error> {
-        for entity in entities {
-            self.create_entity(entity).await?;
-        }
-        Ok(())
-    }
-
-    async fn create_entity(&self, entity: &MemoryEntity) -> MemoryResult<(), Self::Error>;
+    async fn create_entities(&self, entities: &[MemoryEntity]) -> MemoryResult<(), Self::Error>;
     async fn find_entity_by_name(
         &self,
         name: &str,
@@ -46,15 +39,5 @@ pub trait MemoryRepository {
     async fn create_relationships(
         &self,
         relationships: &[MemoryRelationship],
-    ) -> MemoryResult<(), Self::Error> {
-        for relationship in relationships {
-            self.create_relationship(relationship).await?;
-        }
-        Ok(())
-    }
-
-    async fn create_relationship(
-        &self,
-        relationship: &MemoryRelationship,
     ) -> MemoryResult<(), Self::Error>;
 }


### PR DESCRIPTION
## Summary
- remove `create_entity` and `create_relationship` APIs from `MemoryService`
- simplify `MemoryRepository` to expose only batched methods
- update Neo4j repository to implement only batched create operations
- refactor unit and integration tests to use batched APIs

## Testing
- `cargo check`
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_6851cc43d788832791f30a8d2dc8d3bb