### PR TITLE
Add crate summaries

### DIFF
--- a/crates/mm-core/src/lib.rs
+++ b/crates/mm-core/src/lib.rs
@@ -1,3 +1,10 @@
+//! Core domain logic for the Middle Manager project.
+//!
+//! This crate represents the application "core" in the hexagonal
+//! architecture. It defines operations on the memory graph and the
+//! ports (interfaces) that adapters must implement. The code here is
+//! completely independent of external protocols or infrastructure and
+//! focuses purely on business rules.
 #![warn(clippy::all)]
 pub mod error;
 mod operations;

--- a/crates/mm-server/src/lib.rs
+++ b/crates/mm-server/src/lib.rs
@@ -1,3 +1,10 @@
+//! MCP server adapter for the Middle Manager project.
+//!
+//! This crate is an outer adapter in the hexagonal architecture. It
+//! exposes the memory graph operations defined in `mm-core` through the
+//! Model Context Protocol (MCP) so external clients can interact with
+//! the system. The server orchestrates requests, translating protocol
+//! calls into core domain operations.
 #![warn(clippy::all)]
 use async_trait::async_trait;
 use std::path::Path;


### PR DESCRIPTION
## Summary
- document mm-core's responsibility as the domain layer
- document mm-server's role as the MCP server adapter

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_6851df7201008327993a446ce7291a9b