### PR TITLE
Add rust-toolchain file and integrate with flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ graph TD
 
 Run `cargo build` from the repository root to compile all crates.
 
-The workspace requires the **Rust 2024 edition**, so ensure your toolchain is up to date.
+The workspace requires the **Rust 2024 edition**. CI pins the toolchain in
+[`rust-toolchain.toml`](./rust-toolchain.toml), so ensure your local setup
+matches that file.
 
 ### Using Nix
 

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,8 @@
       packages = forAllSystems (system:
         let
           pkgs = import nixpkgs { inherit system; overlays = [ rust-overlay.overlays.default ]; };
-          naersk-lib = pkgs.callPackage naersk { };
+          rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+          naersk-lib = pkgs.callPackage naersk { cargo = rustToolchain; rustc = rustToolchain; };
         in
         rec {
           middle_manager = naersk-lib.buildPackage {
@@ -44,11 +45,14 @@
       );
 
       devShells = forAllSystems (system:
-        let pkgs = import nixpkgs { inherit system; overlays = [ rust-overlay.overlays.default ]; }; in
+        let
+          pkgs = import nixpkgs { inherit system; overlays = [ rust-overlay.overlays.default ]; };
+          rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+        in
         {
           default = pkgs.mkShell {
             buildInputs = with pkgs; [
-              rust-bin.stable.latest.default
+              rustToolchain
               rust-analyzer
               clippy
               rustfmt

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Summary
- pin Rust toolchain to the stable channel
- reference the `rust-toolchain.toml` file in the build docs
- load the pinned toolchain in `flake.nix` for packages and dev shell

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_6851df63023c8327a6b20591f05bdd84