### PR TITLE
Add tracing instrumentation for operations

### DIFF
--- a/crates/mm-core/src/operations/add_observations.rs
+++ b/crates/mm-core/src/operations/add_observations.rs
@@ -2,6 +2,7 @@ use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
 use crate::validate_name;
 use mm_memory::MemoryRepository;
+use tracing::instrument;
 
 #[derive(Debug, Clone)]
 pub struct AddObservationsCommand {
@@ -11,6 +12,7 @@ pub struct AddObservationsCommand {
 
 pub type AddObservationsResult<E> = CoreResult<(), E>;
 
+#[instrument(skip(ports), fields(name = %command.name, observations_count = command.observations.len()))]
 pub async fn add_observations<R>(
     ports: &Ports<R>,
     command: AddObservationsCommand,

--- a/crates/mm-core/src/operations/create_entity.rs
+++ b/crates/mm-core/src/operations/create_entity.rs
@@ -2,6 +2,7 @@ use crate::MemoryEntity;
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
 use mm_memory::MemoryRepository;
+use tracing::instrument;
 
 /// Command to create a new entity
 #[derive(Debug, Clone)]
@@ -22,6 +23,7 @@ pub type CreateEntityResult<E> = CoreResult<(), E>;
 /// # Returns
 ///
 /// Ok(()) if the entity was created successfully, or an error
+#[instrument(skip(ports), fields(entities_count = command.entities.len()))]
 pub async fn create_entity<R>(
     ports: &Ports<R>,
     command: CreateEntityCommand,

--- a/crates/mm-core/src/operations/create_relationship.rs
+++ b/crates/mm-core/src/operations/create_relationship.rs
@@ -1,6 +1,7 @@
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
 use mm_memory::{MemoryRelationship, MemoryRepository};
+use tracing::instrument;
 
 #[derive(Debug, Clone)]
 pub struct CreateRelationshipCommand {
@@ -9,6 +10,7 @@ pub struct CreateRelationshipCommand {
 
 pub type CreateRelationshipResult<E> = CoreResult<(), E>;
 
+#[instrument(skip(ports), fields(relationships_count = command.relationships.len()))]
 pub async fn create_relationship<R>(
     ports: &Ports<R>,
     command: CreateRelationshipCommand,

--- a/crates/mm-core/src/operations/get_entity.rs
+++ b/crates/mm-core/src/operations/get_entity.rs
@@ -3,6 +3,7 @@ use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
 use crate::validate_name;
 use mm_memory::MemoryRepository;
+use tracing::instrument;
 
 /// Command to retrieve an entity by name
 #[derive(Debug, Clone)]
@@ -24,6 +25,7 @@ pub type GetEntityResult<E> = CoreResult<Option<MemoryEntity>, E>;
 /// # Returns
 ///
 /// The entity if found, or None if not found
+#[instrument(skip(ports), fields(name = %command.name))]
 pub async fn get_entity<R>(ports: &Ports<R>, command: GetEntityCommand) -> GetEntityResult<R::Error>
 where
     R: MemoryRepository + Send + Sync,

--- a/crates/mm-core/src/operations/remove_all_observations.rs
+++ b/crates/mm-core/src/operations/remove_all_observations.rs
@@ -2,6 +2,7 @@ use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
 use crate::validate_name;
 use mm_memory::MemoryRepository;
+use tracing::instrument;
 
 #[derive(Debug, Clone)]
 pub struct RemoveAllObservationsCommand {
@@ -10,6 +11,7 @@ pub struct RemoveAllObservationsCommand {
 
 pub type RemoveAllObservationsResult<E> = CoreResult<(), E>;
 
+#[instrument(skip(ports), fields(name = %command.name))]
 pub async fn remove_all_observations<R>(
     ports: &Ports<R>,
     command: RemoveAllObservationsCommand,

--- a/crates/mm-core/src/operations/remove_observations.rs
+++ b/crates/mm-core/src/operations/remove_observations.rs
@@ -2,6 +2,7 @@ use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
 use crate::validate_name;
 use mm_memory::MemoryRepository;
+use tracing::instrument;
 
 #[derive(Debug, Clone)]
 pub struct RemoveObservationsCommand {
@@ -11,6 +12,7 @@ pub struct RemoveObservationsCommand {
 
 pub type RemoveObservationsResult<E> = CoreResult<(), E>;
 
+#[instrument(skip(ports), fields(name = %command.name, observations_count = command.observations.len()))]
 pub async fn remove_observations<R>(
     ports: &Ports<R>,
     command: RemoveObservationsCommand,

--- a/crates/mm-core/src/operations/set_observations.rs
+++ b/crates/mm-core/src/operations/set_observations.rs
@@ -2,6 +2,7 @@ use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
 use crate::validate_name;
 use mm_memory::MemoryRepository;
+use tracing::instrument;
 
 #[derive(Debug, Clone)]
 pub struct SetObservationsCommand {
@@ -11,6 +12,7 @@ pub struct SetObservationsCommand {
 
 pub type SetObservationsResult<E> = CoreResult<(), E>;
 
+#[instrument(skip(ports), fields(name = %command.name, observations_count = command.observations.len()))]
 pub async fn set_observations<R>(
     ports: &Ports<R>,
     command: SetObservationsCommand,


### PR DESCRIPTION
## Summary
- instrument operations functions in `mm-core` with `tracing`
- capture entity/relationship counts and names in spans

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_6851efb6667c832790a9c3649e2b5b06