### PR TITLE
Add tracing instrumentation to memory service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1341,6 +1341,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/mm-memory/Cargo.toml
+++ b/crates/mm-memory/Cargo.toml
@@ -15,6 +15,7 @@ async-trait = { workspace = true }
 mockall = { workspace = true, optional = true }
 mm-utils = { path = "../mm-utils" }
 rust-mcp-sdk = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/mm-memory/src/service.rs
+++ b/crates/mm-memory/src/service.rs
@@ -3,6 +3,7 @@ use crate::{
     MemoryResult, ValidationError, ValidationErrorKind,
 };
 use mm_utils::is_snake_case;
+use tracing::instrument;
 
 /// Service for memory operations
 ///
@@ -33,6 +34,7 @@ where
     }
 
     /// Create multiple entities in a batch
+    #[instrument(skip(self, entities), fields(entities_count = entities.len()))]
     pub async fn create_entities(
         &self,
         entities: &[MemoryEntity],
@@ -71,6 +73,7 @@ where
     }
 
     /// Find an entity by name
+    #[instrument(skip(self), fields(name))]
     pub async fn find_entity_by_name(
         &self,
         name: &str,
@@ -79,6 +82,7 @@ where
     }
 
     /// Replace all observations for an entity
+    #[instrument(skip(self, observations), fields(name, observations_count = observations.len()))]
     pub async fn set_observations(
         &self,
         name: &str,
@@ -88,6 +92,7 @@ where
     }
 
     /// Add observations to an entity
+    #[instrument(skip(self, observations), fields(name, observations_count = observations.len()))]
     pub async fn add_observations(
         &self,
         name: &str,
@@ -97,11 +102,13 @@ where
     }
 
     /// Remove all observations from an entity
+    #[instrument(skip(self), fields(name))]
     pub async fn remove_all_observations(&self, name: &str) -> MemoryResult<(), R::Error> {
         self.repository.remove_all_observations(name).await
     }
 
     /// Remove specific observations from an entity
+    #[instrument(skip(self, observations), fields(name, observations_count = observations.len()))]
     pub async fn remove_observations(
         &self,
         name: &str,
@@ -113,6 +120,7 @@ where
     }
 
     /// Create multiple relationships in a batch
+    #[instrument(skip(self, relationships), fields(relationships_count = relationships.len()))]
     pub async fn create_relationships(
         &self,
         relationships: &[MemoryRelationship],


### PR DESCRIPTION
## Summary
- add `tracing` as a dependency for `mm-memory`
- instrument `MemoryService` operations with `#[instrument]` for better logging

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_6851efc142008327b602e0dca5b2f729