### PR TITLE
Add tracing instrumentation

### DIFF
--- a/crates/mm-memory-neo4j/src/adapters/neo4j.rs
+++ b/crates/mm-memory-neo4j/src/adapters/neo4j.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use neo4rs::{self, Graph, Node, Query};
 use serde_json;
 use std::collections::HashMap;
+use tracing::instrument;
 
 use mm_memory::{
     MemoryEntity, MemoryError, MemoryRelationship, MemoryRepository, MemoryResult, ValidationError,
@@ -47,6 +48,7 @@ impl Neo4jRepository {
     /// # Errors
     ///
     /// Returns a `MemoryError` if the connection to Neo4j fails
+    #[instrument(skip(config), fields(uri = %config.uri))]
     pub async fn new(config: Neo4jConfig) -> Result<Self, MemoryError<neo4rs::Error>> {
         let graph = Graph::new(&config.uri, &config.username, &config.password)
             .await
@@ -64,6 +66,7 @@ impl Neo4jRepository {
 #[async_trait]
 impl MemoryRepository for Neo4jRepository {
     type Error = neo4rs::Error;
+    #[instrument(skip(self, entities), fields(count = entities.len()))]
     async fn create_entities(&self, entities: &[MemoryEntity]) -> MemoryResult<(), Self::Error> {
         if entities.is_empty() {
             return Ok(());
@@ -98,6 +101,7 @@ impl MemoryRepository for Neo4jRepository {
         Ok(())
     }
 
+    #[instrument(skip(self), fields(name = %name))]
     async fn find_entity_by_name(
         &self,
         name: &str,
@@ -183,6 +187,7 @@ impl MemoryRepository for Neo4jRepository {
         }
     }
 
+    #[instrument(skip(self, observations), fields(name = %name))]
     async fn set_observations(
         &self,
         name: &str,
@@ -208,6 +213,7 @@ impl MemoryRepository for Neo4jRepository {
         Ok(())
     }
 
+    #[instrument(skip(self, observations), fields(name = %name))]
     async fn add_observations(
         &self,
         name: &str,
@@ -221,10 +227,12 @@ impl MemoryRepository for Neo4jRepository {
         self.set_observations(name, &current).await
     }
 
+    #[instrument(skip(self), fields(name = %name))]
     async fn remove_all_observations(&self, name: &str) -> MemoryResult<(), Self::Error> {
         self.set_observations(name, &[]).await
     }
 
+    #[instrument(skip(self, observations), fields(name = %name))]
     async fn remove_observations(
         &self,
         name: &str,
@@ -238,6 +246,7 @@ impl MemoryRepository for Neo4jRepository {
         self.set_observations(name, &current).await
     }
 
+    #[instrument(skip(self, relationships), fields(count = relationships.len()))]
     async fn create_relationships(
         &self,
         relationships: &[MemoryRelationship],

--- a/crates/mm-memory-neo4j/src/lib.rs
+++ b/crates/mm-memory-neo4j/src/lib.rs
@@ -33,6 +33,8 @@ All relationships in the knowledge graph follow snake_case naming convention:
 */
 #![warn(clippy::all)]
 
+use tracing::instrument;
+
 pub mod adapters;
 
 // Re-export main types for convenience
@@ -82,6 +84,7 @@ pub type Error = neo4rs::Error;
 ///     Ok(())
 /// }
 /// ```
+#[instrument(fields(uri = %config.uri))]
 pub async fn create_neo4j_service(
     config: Neo4jConfig,
     memory_config: MemoryConfig,


### PR DESCRIPTION
## Summary
- instrument `create_neo4j_service` with connection URI
- add tracing spans for Neo4j repository methods

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_6851efce4b208327bb2b446b9514147b