### PR TITLE
Refine default relationships

### DIFF
--- a/crates/mm-core/src/operations/create_relationship.rs
+++ b/crates/mm-core/src/operations/create_relationship.rs
@@ -44,7 +44,7 @@ mod tests {
     async fn test_create_relationship_success() {
         let mut mock = MockMemoryRepository::new();
         mock.expect_create_relationships()
-            .withf(|rels| rels.len() == 1 && rels[0].name == "related_to")
+            .withf(|rels| rels.len() == 1 && rels[0].name == "relates_to")
             .returning(|_| Ok(()));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
@@ -54,7 +54,7 @@ mod tests {
             relationships: vec![MemoryRelationship {
                 from: "a".to_string(),
                 to: "b".to_string(),
-                name: "related_to".to_string(),
+                name: "relates_to".to_string(),
                 properties: HashMap::new(),
             }],
         };

--- a/crates/mm-memory-neo4j/tests/neo4j_integration.rs
+++ b/crates/mm-memory-neo4j/tests/neo4j_integration.rs
@@ -288,7 +288,7 @@ async fn test_create_relationship() {
     let rel = MemoryRelationship {
         from: a.name.clone(),
         to: b.name.clone(),
-        name: "related_to".to_string(),
+        name: "relates_to".to_string(),
         properties: HashMap::new(),
     };
 

--- a/crates/mm-memory/src/config.rs
+++ b/crates/mm-memory/src/config.rs
@@ -21,7 +21,24 @@ pub struct MemoryConfig {
 pub const DEFAULT_MEMORY_TAG: &str = "Memory";
 
 /// Default set of allowed relationship names
-pub const DEFAULT_RELATIONSHIPS: &[&str] = &["related_to", "parent_of", "child_of"];
+pub const DEFAULT_RELATIONSHIPS: &[&str] = &[
+    "relates_to",
+    "owns",
+    "makes",
+    "uses",
+    "uses_when_needed",
+    "contains",
+    "includes",
+    "runs",
+    "works_on",
+    "performs",
+    "branch_of",
+    "follows",
+    "implements",
+    "references",
+    "tagged_with",
+    "example_of",
+];
 
 impl MemoryConfig {
     /// Helper for serde default of boolean true

--- a/crates/mm-memory/src/service.rs
+++ b/crates/mm-memory/src/service.rs
@@ -307,7 +307,7 @@ mod tests {
         let rel = MemoryRelationship {
             from: "a".to_string(),
             to: "b".to_string(),
-            name: "related_to".to_string(),
+            name: "relates_to".to_string(),
             properties: HashMap::new(),
         };
 
@@ -394,7 +394,7 @@ mod tests {
         let rel = MemoryRelationship {
             from: "a".to_string(),
             to: "b".to_string(),
-            name: "related_to".to_string(),
+            name: "relates_to".to_string(),
             properties: HashMap::new(),
         };
 

--- a/crates/mm-server/src/mcp/create_relationship.rs
+++ b/crates/mm-server/src/mcp/create_relationship.rs
@@ -63,7 +63,7 @@ mod tests {
     async fn test_call_tool_success() {
         let mut mock = MockMemoryRepository::new();
         mock.expect_create_relationships()
-            .withf(|rels| rels.len() == 1 && rels[0].name == "related_to")
+            .withf(|rels| rels.len() == 1 && rels[0].name == "relates_to")
             .returning(|_| Ok(()));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
@@ -73,7 +73,7 @@ mod tests {
             relationships: vec![RelationshipInput {
                 from: "a".to_string(),
                 to: "b".to_string(),
-                name: "related_to".to_string(),
+                name: "relates_to".to_string(),
                 properties: Some(HashMap::new()),
             }],
         };
@@ -96,7 +96,7 @@ mod tests {
             relationships: vec![RelationshipInput {
                 from: "a".to_string(),
                 to: "b".to_string(),
-                name: "related_to".to_string(),
+                name: "relates_to".to_string(),
                 properties: Some(HashMap::new()),
             }],
         };


### PR DESCRIPTION
## Summary
- remove deprecated `related_to`, `parent_of`, and `child_of` relationship defaults
- adjust tests to use `relates_to`

## Testing
- `just validate`


------
https://chatgpt.com/codex/tasks/task_e_6851fe5be2f08327a74f1791b2b49545