### PR TITLE
docs: Update AGENTS with memory schema location

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,12 +42,16 @@ middle-manager/
 │   │   ├── src/
 │   │   │   ├── mcp/        # MCP tool implementations
 │   │   │   ├── lib.rs      # Server handler implementation
+│   ├── mm-memory/      # Memory domain types and schema
 │   ├── mm-memory-neo4j/      # Memory graph repository and service
 ├── config/
 │   ├── default.toml    # Default configuration
 │   ├── local.toml      # Local overrides (gitignored)
 ├── justfile            # Common development tasks
 ```
+
+The `mm-memory` crate defines the memory data model. Its schema is stored in
+`crates/mm-memory/schema.json`.
 
 ## Available MCP Resources
 


### PR DESCRIPTION
## Summary
- mention `mm-memory` crate in the project structure
- note that the memory schema lives in `crates/mm-memory/schema.json`

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_685202a4d3688327b59c9584e0a5bd82