### PR TITLE
Add arbitrary-based property tests with arbtest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+
+[[package]]
+name = "arbtest"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3be567977128c0f71ad1462d9624ccda712193d124e944252f0c5789a06d46"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,6 +1395,10 @@ dependencies = [
 [[package]]
 name = "mm-utils"
 version = "0.1.0"
+dependencies = [
+ "arbitrary",
+ "arbtest",
+]
 
 [[package]]
 name = "mockall"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,7 @@ thiserror = "1.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 mockall = "0.12.1"
+arbitrary = "1"
+rand = "0.8"
+fastrand = "2"
+arbtest = "0.3"

--- a/crates/mm-utils/Cargo.toml
+++ b/crates/mm-utils/Cargo.toml
@@ -5,3 +5,7 @@ edition = "2024"
 license = "MPL-2.0"
 
 [dependencies]
+
+[dev-dependencies]
+arbitrary = { workspace = true }
+arbtest = { workspace = true }

--- a/crates/mm-utils/src/lib.rs
+++ b/crates/mm-utils/src/lib.rs
@@ -26,6 +26,57 @@ pub fn is_snake_case(s: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::is_snake_case;
+    use arbitrary::{Arbitrary, Unstructured};
+    use arbtest::arbtest;
+
+    #[derive(Debug)]
+    struct SnakeCaseString(String);
+
+    impl<'a> Arbitrary<'a> for SnakeCaseString {
+        fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+            let len = u.int_in_range::<usize>(0..=20)?;
+            let mut s = String::new();
+            for _ in 0..len {
+                let choice = u.int_in_range::<u8>(0..=36)?;
+                let c = match choice {
+                    0..=25 => (b'a' + choice) as char,
+                    26 => '_',
+                    _ => (b'0' + (choice - 27)) as char,
+                };
+                s.push(c);
+            }
+            Ok(SnakeCaseString(s))
+        }
+    }
+
+    #[derive(Debug)]
+    struct NonSnakeCaseString(String);
+
+    impl<'a> Arbitrary<'a> for NonSnakeCaseString {
+        fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+            let len = u.int_in_range::<usize>(1..=20)?;
+            let invalid_pos = u.int_in_range::<usize>(0..=len - 1)?;
+            let mut s = String::new();
+            for i in 0..len {
+                let c = if i == invalid_pos {
+                    let choice = u.int_in_range::<u8>(0..=26)?;
+                    match choice {
+                        0..=25 => (b'A' + choice) as char,
+                        _ => '-',
+                    }
+                } else {
+                    let choice = u.int_in_range::<u8>(0..=36)?;
+                    match choice {
+                        0..=25 => (b'a' + choice) as char,
+                        26 => '_',
+                        _ => (b'0' + (choice - 27)) as char,
+                    }
+                };
+                s.push(c);
+            }
+            Ok(NonSnakeCaseString(s))
+        }
+    }
 
     #[test]
     fn valid_snake_case_strings() {
@@ -39,5 +90,25 @@ mod tests {
         assert!(!is_snake_case("HelloWorld"));
         assert!(!is_snake_case("Hello_World"));
         assert!(!is_snake_case("hello-world"));
+    }
+
+    #[test]
+    fn arbitrary_valid_strings() {
+        arbtest(|u| {
+            if let Ok(SnakeCaseString(s)) = SnakeCaseString::arbitrary(u) {
+                assert!(is_snake_case(&s), "{}", s);
+            }
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn arbitrary_invalid_strings() {
+        arbtest(|u| {
+            if let Ok(NonSnakeCaseString(s)) = NonSnakeCaseString::arbitrary(u) {
+                assert!(!is_snake_case(&s), "{}", s);
+            }
+            Ok(())
+        });
     }
 }


### PR DESCRIPTION
## Summary
- make `rand` and `fastrand` shared workspace dependencies
- use the `arbtest` crate for randomized snake_case tests
- add `arbtest` as a workspace dependency

## Testing
- `just validate`


------
https://chatgpt.com/codex/tasks/task_e_68520dca3f348327b4430aa4cdabe301