### PR TITLE
Add fuzz tests for memory service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1348,6 +1348,8 @@ dependencies = [
 name = "mm-memory"
 version = "0.1.0"
 dependencies = [
+ "arbitrary",
+ "arbtest",
  "async-trait",
  "mm-utils",
  "mockall",

--- a/crates/mm-memory/Cargo.toml
+++ b/crates/mm-memory/Cargo.toml
@@ -6,6 +6,7 @@ license = "MPL-2.0"
 
 [features]
 mock = ["mockall"]
+arbitrary = ["dep:arbitrary"]
 
 [dependencies]
 serde = { workspace = true }
@@ -16,7 +17,10 @@ mockall = { workspace = true, optional = true }
 mm-utils = { path = "../mm-utils" }
 rust-mcp-sdk = { workspace = true }
 tracing = { workspace = true }
+arbitrary = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }
 mockall = { workspace = true }
+arbitrary = { workspace = true }
+arbtest = { workspace = true }

--- a/crates/mm-memory/src/entity.rs
+++ b/crates/mm-memory/src/entity.rs
@@ -2,6 +2,11 @@ use rust_mcp_sdk::macros::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+#[cfg(feature = "arbitrary")]
+use crate::DEFAULT_LABELS;
+#[cfg(feature = "arbitrary")]
+use arbitrary::{Arbitrary, Unstructured};
+
 /// Memory entity representing a node in the knowledge graph
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, JsonSchema)]
 pub struct MemoryEntity {
@@ -14,4 +19,63 @@ pub struct MemoryEntity {
     /// Additional key-value properties
     #[serde(default)]
     pub properties: HashMap<String, String>,
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> Arbitrary<'a> for MemoryEntity {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let name_len = u.int_in_range::<usize>(1..=10)?;
+        let mut name = String::new();
+        for _ in 0..name_len {
+            let ch = (b'a' + u.int_in_range::<u8>(0..=25)?) as char;
+            name.push(ch);
+        }
+
+        let has_labels = u.arbitrary::<bool>()?;
+        let label_count = if has_labels {
+            u.int_in_range::<usize>(1..=3)?
+        } else {
+            0
+        };
+        let mut labels = Vec::new();
+        for _ in 0..label_count {
+            let idx = u.int_in_range::<usize>(0..=DEFAULT_LABELS.len() - 1)?;
+            labels.push(DEFAULT_LABELS[idx].to_string());
+        }
+
+        let obs_count = u.int_in_range::<usize>(0..=3)?;
+        let mut observations = Vec::new();
+        for _ in 0..obs_count {
+            let len = u.int_in_range::<usize>(1..=10)?;
+            let mut s = String::new();
+            for _ in 0..len {
+                let ch = (b'a' + u.int_in_range::<u8>(0..=25)?) as char;
+                s.push(ch);
+            }
+            observations.push(s);
+        }
+
+        let prop_count = u.int_in_range::<usize>(0..=2)?;
+        let mut properties = HashMap::new();
+        for _ in 0..prop_count {
+            let key_len = u.int_in_range::<usize>(1..=5)?;
+            let mut key = String::new();
+            for _ in 0..key_len {
+                key.push((b'a' + u.int_in_range::<u8>(0..=25)?) as char);
+            }
+            let val_len = u.int_in_range::<usize>(1..=5)?;
+            let mut val = String::new();
+            for _ in 0..val_len {
+                val.push((b'a' + u.int_in_range::<u8>(0..=25)?) as char);
+            }
+            properties.insert(key, val);
+        }
+
+        Ok(Self {
+            name,
+            labels,
+            observations,
+            properties,
+        })
+    }
 }

--- a/crates/mm-memory/src/relationship.rs
+++ b/crates/mm-memory/src/relationship.rs
@@ -2,6 +2,11 @@ use rust_mcp_sdk::macros::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+#[cfg(feature = "arbitrary")]
+use arbitrary::{Arbitrary, Unstructured};
+#[cfg(feature = "arbitrary")]
+use mm_utils::is_snake_case;
+
 /// Memory relationship representing an edge between entities
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, JsonSchema)]
 pub struct MemoryRelationship {
@@ -14,4 +19,52 @@ pub struct MemoryRelationship {
     /// Additional key-value properties
     #[serde(default)]
     pub properties: HashMap<String, String>,
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> Arbitrary<'a> for MemoryRelationship {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let str_len = |rng: std::ops::RangeInclusive<usize>,
+                       u: &mut Unstructured<'a>|
+         -> arbitrary::Result<String> {
+            let len = u.int_in_range(rng)?;
+            let mut s = String::new();
+            for _ in 0..len {
+                s.push((b'a' + u.int_in_range::<u8>(0..=25)?) as char);
+            }
+            Ok(s)
+        };
+
+        let from = str_len(1..=8, u)?;
+        let to = str_len(1..=8, u)?;
+
+        let valid_name = u.arbitrary::<bool>()?;
+        let name = if valid_name {
+            str_len(3..=10, u)?
+        } else {
+            let mut s = str_len(3..=10, u)?;
+            if is_snake_case(&s) {
+                // introduce an uppercase character to break snake_case
+                let pos = u.int_in_range::<usize>(0..=s.len() - 1)?;
+                let ch = (b'A' + u.int_in_range::<u8>(0..=25)?) as char;
+                s.replace_range(pos..=pos, &ch.to_string());
+            }
+            s
+        };
+
+        let prop_count = u.int_in_range::<usize>(0..=2)?;
+        let mut properties = HashMap::new();
+        for _ in 0..prop_count {
+            let key = str_len(1..=5, u)?;
+            let val = str_len(1..=5, u)?;
+            properties.insert(key, val);
+        }
+
+        Ok(Self {
+            from,
+            to,
+            name,
+            properties,
+        })
+    }
 }

--- a/crates/mm-memory/tests/service_fuzz.rs
+++ b/crates/mm-memory/tests/service_fuzz.rs
@@ -1,0 +1,115 @@
+use arbitrary::Arbitrary;
+use arbtest::arbtest;
+use mm_memory::{
+    MemoryConfig, MemoryEntity, MemoryRelationship, MemoryService, MockMemoryRepository,
+    ValidationErrorKind,
+};
+use mm_utils::is_snake_case;
+use std::collections::HashSet;
+
+fn runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+}
+
+#[test]
+fn fuzz_create_entities() {
+    arbtest(|u| {
+        let count = u.int_in_range::<usize>(0..=5)?;
+        let mut entities = Vec::new();
+        for _ in 0..count {
+            entities.push(MemoryEntity::arbitrary(u)?);
+        }
+
+        let valid: Vec<_> = entities
+            .iter()
+            .cloned()
+            .filter(|e| !e.labels.is_empty())
+            .collect();
+
+        let mut mock = MockMemoryRepository::new();
+        mock.expect_create_entities()
+            .withf(move |e| e.iter().all(|en| !en.labels.is_empty()) && e.len() == valid.len())
+            .returning(|_| Ok(()));
+
+        let service = MemoryService::new(
+            mock,
+            MemoryConfig {
+                default_tag: None,
+                default_relationships: false,
+                additional_relationships: HashSet::new(),
+                default_labels: false,
+                additional_labels: HashSet::new(),
+            },
+        );
+
+        let errors = runtime()
+            .block_on(async { service.create_entities(&entities).await })
+            .unwrap();
+
+        for entity in &entities {
+            let err = errors.iter().find(|(n, _)| n == &entity.name);
+            if entity.labels.is_empty() {
+                let (_, ve) = err.expect("missing error for invalid entity");
+                assert!(ve.0.contains(&ValidationErrorKind::NoLabels(entity.name.clone())));
+            } else {
+                assert!(err.is_none());
+            }
+        }
+        Ok(())
+    });
+}
+
+#[test]
+fn fuzz_create_relationships() {
+    arbtest(|u| {
+        let count = u.int_in_range::<usize>(0..=5)?;
+        let mut rels = Vec::new();
+        for _ in 0..count {
+            rels.push(MemoryRelationship::arbitrary(u)?);
+        }
+
+        let valid: Vec<_> = rels
+            .iter()
+            .cloned()
+            .filter(|r| is_snake_case(&r.name))
+            .collect();
+
+        let mut mock = MockMemoryRepository::new();
+        mock.expect_create_relationships()
+            .withf(move |rs| rs.iter().all(|r| is_snake_case(&r.name)) && rs.len() == valid.len())
+            .returning(|_| Ok(()));
+
+        let service = MemoryService::new(
+            mock,
+            MemoryConfig {
+                default_tag: None,
+                default_relationships: false,
+                additional_relationships: HashSet::new(),
+                default_labels: false,
+                additional_labels: HashSet::new(),
+            },
+        );
+
+        let errors = runtime()
+            .block_on(async { service.create_relationships(&rels).await })
+            .unwrap();
+
+        for rel in &rels {
+            let err = errors.iter().find(|(n, _)| n == &rel.name);
+            if !is_snake_case(&rel.name) {
+                let (_, ve) = err.expect("missing error for invalid relationship");
+                assert!(
+                    ve.0.contains(&ValidationErrorKind::InvalidRelationshipFormat(
+                        rel.name.clone()
+                    ))
+                );
+            } else {
+                assert!(err.is_none());
+            }
+        }
+        Ok(())
+    });
+}


### PR DESCRIPTION
## Summary
- support arbitrary generators behind new `arbitrary` feature
- derive `Arbitrary` for `MemoryEntity` and `MemoryRelationship`
- add property-based fuzz tests for `MemoryService`
- include `arbitrary` and `arbtest` as dev-dependencies

## Testing
- `just validate`
- `cargo test -p mm-memory --tests --features "mock arbitrary"`

------
https://chatgpt.com/codex/tasks/task_e_685221d10ba4832791228e58c9cab4a5