### PR TITLE
Add Arbitrary impls and fuzz tests for tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1382,11 +1382,14 @@ name = "mm-server"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arbitrary",
+ "arbtest",
  "async-trait",
  "config",
  "mm-core",
  "mm-memory",
  "mm-memory-neo4j",
+ "mm-utils",
  "mockall",
  "rust-mcp-sdk",
  "serde",

--- a/crates/mm-server/Cargo.toml
+++ b/crates/mm-server/Cargo.toml
@@ -21,8 +21,13 @@ tracing = { workspace = true }
 anyhow = "1.0"
 async-trait = { workspace = true }
 config = "0.15.11"
+arbitrary = { workspace = true }
+mm-utils = { path = "../mm-utils" }
 
 [dev-dependencies]
 mm-memory = { path = "../mm-memory", features = ["mock"] }
 tokio = { workspace = true, features = ["full", "test-util"] }
 mockall = { workspace = true }
+arbitrary = { workspace = true }
+arbtest = { workspace = true }
+mm-utils = { path = "../mm-utils" }

--- a/crates/mm-server/src/lib.rs
+++ b/crates/mm-server/src/lib.rs
@@ -35,6 +35,11 @@ use tracing::debug;
 
 mod mcp;
 use mcp::MemoryTools;
+pub use mcp::create_relationship::RelationshipInput;
+pub use mcp::{
+    AddObservationsTool, CreateEntityTool, CreateRelationshipTool, GetEntityTool,
+    RemoveAllObservationsTool, RemoveObservationsTool, SetObservationsTool,
+};
 mod resources;
 
 /// Middle Manager MCP server handler

--- a/crates/mm-server/src/mcp/add_observations.rs
+++ b/crates/mm-server/src/mcp/add_observations.rs
@@ -12,6 +12,17 @@ pub struct AddObservationsTool {
     pub observations: Vec<String>,
 }
 
+use arbitrary::{Arbitrary, Unstructured};
+use mm_utils::prop::NonEmptyName;
+
+impl<'a> Arbitrary<'a> for AddObservationsTool {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let NonEmptyName(name) = NonEmptyName::arbitrary(u)?;
+        let observations = <Vec<String>>::arbitrary(u)?;
+        Ok(Self { name, observations })
+    }
+}
+
 impl AddObservationsTool {
     generate_call_tool!(
         self,

--- a/crates/mm-server/src/mcp/create_entity.rs
+++ b/crates/mm-server/src/mcp/create_entity.rs
@@ -12,6 +12,32 @@ pub struct CreateEntityTool {
     pub entities: Vec<MemoryEntity>,
 }
 
+use arbitrary::{Arbitrary, Unstructured};
+use mm_memory::DEFAULT_LABELS;
+use mm_utils::prop::NonEmptyName;
+use std::collections::HashMap;
+
+impl<'a> Arbitrary<'a> for CreateEntityTool {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let len = u.int_in_range::<usize>(1..=3)?;
+        let mut entities = Vec::with_capacity(len);
+        for _ in 0..len {
+            let NonEmptyName(name) = NonEmptyName::arbitrary(u)?;
+            let label_idx = u.int_in_range::<usize>(0..=DEFAULT_LABELS.len() - 1)?;
+            let labels = vec![DEFAULT_LABELS[label_idx].to_string()];
+            let observations = <Vec<String>>::arbitrary(u)?;
+            let properties = <HashMap<String, String>>::arbitrary(u)?;
+            entities.push(MemoryEntity {
+                name,
+                labels,
+                observations,
+                properties,
+            });
+        }
+        Ok(Self { entities })
+    }
+}
+
 impl CreateEntityTool {
     generate_call_tool!(
         self,

--- a/crates/mm-server/src/mcp/get_entity.rs
+++ b/crates/mm-server/src/mcp/get_entity.rs
@@ -13,6 +13,16 @@ pub struct GetEntityTool {
     pub name: String,
 }
 
+use arbitrary::{Arbitrary, Unstructured};
+use mm_utils::prop::NonEmptyName;
+
+impl<'a> Arbitrary<'a> for GetEntityTool {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let NonEmptyName(name) = NonEmptyName::arbitrary(u)?;
+        Ok(Self { name })
+    }
+}
+
 impl GetEntityTool {
     generate_call_tool!(
         self,

--- a/crates/mm-server/src/mcp/remove_all_observations.rs
+++ b/crates/mm-server/src/mcp/remove_all_observations.rs
@@ -11,6 +11,16 @@ pub struct RemoveAllObservationsTool {
     pub name: String,
 }
 
+use arbitrary::{Arbitrary, Unstructured};
+use mm_utils::prop::NonEmptyName;
+
+impl<'a> Arbitrary<'a> for RemoveAllObservationsTool {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let NonEmptyName(name) = NonEmptyName::arbitrary(u)?;
+        Ok(Self { name })
+    }
+}
+
 impl RemoveAllObservationsTool {
     generate_call_tool!(
         self,

--- a/crates/mm-server/src/mcp/remove_observations.rs
+++ b/crates/mm-server/src/mcp/remove_observations.rs
@@ -12,6 +12,17 @@ pub struct RemoveObservationsTool {
     pub observations: Vec<String>,
 }
 
+use arbitrary::{Arbitrary, Unstructured};
+use mm_utils::prop::NonEmptyName;
+
+impl<'a> Arbitrary<'a> for RemoveObservationsTool {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let NonEmptyName(name) = NonEmptyName::arbitrary(u)?;
+        let observations = <Vec<String>>::arbitrary(u)?;
+        Ok(Self { name, observations })
+    }
+}
+
 impl RemoveObservationsTool {
     generate_call_tool!(
         self,

--- a/crates/mm-server/src/mcp/set_observations.rs
+++ b/crates/mm-server/src/mcp/set_observations.rs
@@ -12,6 +12,17 @@ pub struct SetObservationsTool {
     pub observations: Vec<String>,
 }
 
+use arbitrary::{Arbitrary, Unstructured};
+use mm_utils::prop::NonEmptyName;
+
+impl<'a> Arbitrary<'a> for SetObservationsTool {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let NonEmptyName(name) = NonEmptyName::arbitrary(u)?;
+        let observations = <Vec<String>>::arbitrary(u)?;
+        Ok(Self { name, observations })
+    }
+}
+
 impl SetObservationsTool {
     generate_call_tool!(
         self,

--- a/crates/mm-server/tests/tool_fuzz.rs
+++ b/crates/mm-server/tests/tool_fuzz.rs
@@ -1,0 +1,269 @@
+use arbitrary::Arbitrary;
+use mm_core::Ports;
+use mm_memory::{MemoryConfig, MemoryEntity, MemoryService, MockMemoryRepository};
+use mm_server::{
+    AddObservationsTool, CreateEntityTool, CreateRelationshipTool, GetEntityTool,
+    RelationshipInput, RemoveAllObservationsTool, RemoveObservationsTool, SetObservationsTool,
+};
+use mm_utils::prop::async_arbtest;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+#[test]
+fn fuzz_add_observations_tool() {
+    async_arbtest(|rt, u| {
+        let tool = AddObservationsTool::arbitrary(u)?;
+        let mut mock = MockMemoryRepository::new();
+        let name = tool.name.clone();
+        let obs = tool.observations.clone();
+        mock.expect_add_observations()
+            .withf(move |n, o| n == name && o == obs.as_slice())
+            .returning(|_, _| Ok(()));
+        let service = MemoryService::new(mock, MemoryConfig::default());
+        let ports = Ports::new(Arc::new(service));
+        let result = rt.block_on(tool.call_tool(&ports));
+        assert!(result.is_ok());
+        Ok(())
+    });
+}
+
+#[test]
+fn fuzz_set_observations_tool() {
+    async_arbtest(|rt, u| {
+        let tool = SetObservationsTool::arbitrary(u)?;
+        let mut mock = MockMemoryRepository::new();
+        let name = tool.name.clone();
+        let obs = tool.observations.clone();
+        mock.expect_set_observations()
+            .withf(move |n, o| n == name && o == obs.as_slice())
+            .returning(|_, _| Ok(()));
+        let service = MemoryService::new(mock, MemoryConfig::default());
+        let ports = Ports::new(Arc::new(service));
+        let result = rt.block_on(tool.call_tool(&ports));
+        assert!(result.is_ok());
+        Ok(())
+    });
+}
+
+#[test]
+fn fuzz_remove_observations_tool() {
+    async_arbtest(|rt, u| {
+        let tool = RemoveObservationsTool::arbitrary(u)?;
+        let mut mock = MockMemoryRepository::new();
+        let name = tool.name.clone();
+        let obs = tool.observations.clone();
+        mock.expect_remove_observations()
+            .withf(move |n, o| n == name && o == obs.as_slice())
+            .returning(|_, _| Ok(()));
+        let service = MemoryService::new(mock, MemoryConfig::default());
+        let ports = Ports::new(Arc::new(service));
+        let result = rt.block_on(tool.call_tool(&ports));
+        assert!(result.is_ok());
+        Ok(())
+    });
+}
+
+#[test]
+fn fuzz_remove_all_observations_tool() {
+    async_arbtest(|rt, u| {
+        let tool = RemoveAllObservationsTool::arbitrary(u)?;
+        let mut mock = MockMemoryRepository::new();
+        let name = tool.name.clone();
+        mock.expect_remove_all_observations()
+            .withf(move |n| n == name)
+            .returning(|_| Ok(()));
+        let service = MemoryService::new(mock, MemoryConfig::default());
+        let ports = Ports::new(Arc::new(service));
+        let result = rt.block_on(tool.call_tool(&ports));
+        assert!(result.is_ok());
+        Ok(())
+    });
+}
+
+#[test]
+fn fuzz_get_entity_tool() {
+    async_arbtest(|rt, u| {
+        let tool = GetEntityTool::arbitrary(u)?;
+        let mut mock = MockMemoryRepository::new();
+        let name = tool.name.clone();
+        let name_with = name.clone();
+        mock.expect_find_entity_by_name()
+            .withf(move |n| n == name_with)
+            .returning(move |_| {
+                Ok(Some(MemoryEntity {
+                    name: name.clone(),
+                    labels: vec![],
+                    observations: vec![],
+                    properties: HashMap::new(),
+                }))
+            });
+        let service = MemoryService::new(mock, MemoryConfig::default());
+        let ports = Ports::new(Arc::new(service));
+        let result = rt.block_on(tool.call_tool(&ports));
+        assert!(result.is_ok());
+        Ok(())
+    });
+}
+
+#[test]
+fn fuzz_create_entity_tool() {
+    async_arbtest(|rt, u| {
+        let tool = CreateEntityTool::arbitrary(u)?;
+        let mut mock = MockMemoryRepository::new();
+        let expected = tool.entities.clone();
+        mock.expect_create_entities()
+            .withf(move |ents| ents == expected.as_slice())
+            .returning(|_| Ok(()));
+        let service = MemoryService::new(
+            mock,
+            MemoryConfig {
+                default_labels: false,
+                ..MemoryConfig::default()
+            },
+        );
+        let ports = Ports::new(Arc::new(service));
+        let result = rt.block_on(tool.call_tool(&ports));
+        assert!(result.is_ok());
+        Ok(())
+    });
+}
+
+#[test]
+fn fuzz_create_relationship_tool() {
+    async_arbtest(|rt, u| {
+        let tool = CreateRelationshipTool::arbitrary(u)?;
+        let mut mock = MockMemoryRepository::new();
+        let expected: Vec<_> = tool
+            .relationships
+            .iter()
+            .map(|r| {
+                (
+                    r.from.clone(),
+                    r.to.clone(),
+                    r.name.clone(),
+                    r.properties.clone().unwrap_or_default(),
+                )
+            })
+            .collect();
+        let expected_clone = expected.clone();
+        mock.expect_create_relationships()
+            .withf(move |rels| {
+                rels.len() == expected_clone.len()
+                    && rels.iter().zip(expected_clone.iter()).all(|(a, e)| {
+                        a.from == e.0 && a.to == e.1 && a.name == e.2 && a.properties == e.3
+                    })
+            })
+            .returning(|_| Ok(()));
+        let service = MemoryService::new(mock, MemoryConfig::default());
+        let ports = Ports::new(Arc::new(service));
+        let result = rt.block_on(tool.call_tool(&ports));
+        assert!(result.is_ok());
+        Ok(())
+    });
+}
+
+// Invalid parameter checks
+
+#[tokio::test]
+async fn invalid_add_observations_empty_name() {
+    let mut mock = MockMemoryRepository::new();
+    mock.expect_add_observations().never();
+    let service = MemoryService::new(mock, MemoryConfig::default());
+    let ports = Ports::new(Arc::new(service));
+    let tool = AddObservationsTool {
+        name: String::new(),
+        observations: vec![],
+    };
+    let result = tool.call_tool(&ports).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn invalid_set_observations_empty_name() {
+    let mut mock = MockMemoryRepository::new();
+    mock.expect_set_observations().never();
+    let service = MemoryService::new(mock, MemoryConfig::default());
+    let ports = Ports::new(Arc::new(service));
+    let tool = SetObservationsTool {
+        name: String::new(),
+        observations: vec![],
+    };
+    let result = tool.call_tool(&ports).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn invalid_remove_observations_empty_name() {
+    let mut mock = MockMemoryRepository::new();
+    mock.expect_remove_observations().never();
+    let service = MemoryService::new(mock, MemoryConfig::default());
+    let ports = Ports::new(Arc::new(service));
+    let tool = RemoveObservationsTool {
+        name: String::new(),
+        observations: vec![],
+    };
+    let result = tool.call_tool(&ports).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn invalid_remove_all_observations_empty_name() {
+    let mut mock = MockMemoryRepository::new();
+    mock.expect_remove_all_observations().never();
+    let service = MemoryService::new(mock, MemoryConfig::default());
+    let ports = Ports::new(Arc::new(service));
+    let tool = RemoveAllObservationsTool {
+        name: String::new(),
+    };
+    let result = tool.call_tool(&ports).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn invalid_get_entity_empty_name() {
+    let mut mock = MockMemoryRepository::new();
+    mock.expect_find_entity_by_name().never();
+    let service = MemoryService::new(mock, MemoryConfig::default());
+    let ports = Ports::new(Arc::new(service));
+    let tool = GetEntityTool {
+        name: String::new(),
+    };
+    let result = tool.call_tool(&ports).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn invalid_create_entity_empty_name() {
+    let mut mock = MockMemoryRepository::new();
+    mock.expect_create_entities().never();
+    let service = MemoryService::new(mock, MemoryConfig::default());
+    let ports = Ports::new(Arc::new(service));
+    let tool = CreateEntityTool {
+        entities: vec![MemoryEntity {
+            name: String::new(),
+            labels: vec!["Memory".to_string()],
+            observations: vec![],
+            properties: HashMap::new(),
+        }],
+    };
+    let result = tool.call_tool(&ports).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn invalid_create_relationship_empty_name() {
+    let mut mock = MockMemoryRepository::new();
+    mock.expect_create_relationships().never();
+    let service = MemoryService::new(mock, MemoryConfig::default());
+    let ports = Ports::new(Arc::new(service));
+    let tool = CreateRelationshipTool {
+        relationships: vec![RelationshipInput {
+            from: "a".to_string(),
+            to: "b".to_string(),
+            name: String::new(),
+            properties: None,
+        }],
+    };
+    let result = tool.call_tool(&ports).await;
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary
- add `arbitrary` and `arbtest` for mm-server tests
- implement `Arbitrary` for MCP tools
- export tools from mm-server crate
- create fuzz test exercising tool calls and error cases

## Testing
- `cargo test --workspace --lib --no-run` *(fails: process killed or environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_6852346263808327887c1f8bc9afc953