### PR TITLE
refactor(tests): Add property helpers and rename prop test modules

### DIFF
--- a/crates/mm-memory/src/service.rs
+++ b/crates/mm-memory/src/service.rs
@@ -498,7 +498,7 @@ mod tests {
         assert!(matches!(result, Err(crate::MemoryError::QueryError { .. })));
     }
 
-    mod prop {
+    mod prop_tests {
         use super::*;
         use arbitrary::{Arbitrary, Unstructured};
         use mm_utils::prop::{self, NonEmptyName, async_arbtest};
@@ -514,21 +514,9 @@ mod tests {
                     });
                 }
                 let name = prop::small_string(u)?;
-                let label_count = u.int_in_range::<usize>(0..=3)?;
-                let mut labels = Vec::new();
-                for _ in 0..label_count {
-                    labels.push(prop::small_string(u)?);
-                }
-                let obs_count = u.int_in_range::<usize>(0..=3)?;
-                let mut observations = Vec::new();
-                for _ in 0..obs_count {
-                    observations.push(prop::small_string(u)?);
-                }
-                let prop_count = u.int_in_range::<usize>(0..=3)?;
-                let mut properties = std::collections::HashMap::new();
-                for _ in 0..prop_count {
-                    properties.insert(prop::small_string(u)?, prop::small_string(u)?);
-                }
+                let labels = prop::small_string_vec(u, 3)?;
+                let observations = prop::small_string_vec(u, 3)?;
+                let properties = prop::small_string_map(u, 3)?;
                 Ok(Self {
                     name,
                     labels,
@@ -551,11 +539,7 @@ mod tests {
                 let from = prop::small_string(u)?;
                 let to = prop::small_string(u)?;
                 let name = prop::small_string(u)?;
-                let prop_count = u.int_in_range::<usize>(0..=3)?;
-                let mut properties = std::collections::HashMap::new();
-                for _ in 0..prop_count {
-                    properties.insert(prop::small_string(u)?, prop::small_string(u)?);
-                }
+                let properties = prop::small_string_map(u, 3)?;
                 Ok(Self {
                     from,
                     to,

--- a/crates/mm-utils/src/prop.rs
+++ b/crates/mm-utils/src/prop.rs
@@ -1,5 +1,6 @@
 use arbitrary::{Arbitrary, Unstructured};
 use arbtest::arbtest;
+use std::collections::HashMap;
 
 #[derive(Debug)]
 pub struct NonEmptyName(pub String);
@@ -37,4 +38,27 @@ pub fn small_string(u: &mut Unstructured<'_>) -> arbitrary::Result<String> {
         s.push((b % 26 + b'a') as char);
     }
     Ok(s)
+}
+
+/// Generate a vector of up to `max` short strings.
+pub fn small_string_vec(u: &mut Unstructured<'_>, max: usize) -> arbitrary::Result<Vec<String>> {
+    let count = u.int_in_range::<usize>(0..=max)?;
+    let mut items = Vec::with_capacity(count);
+    for _ in 0..count {
+        items.push(small_string(u)?);
+    }
+    Ok(items)
+}
+
+/// Generate a map of up to `max` key/value pairs of short strings.
+pub fn small_string_map(
+    u: &mut Unstructured<'_>,
+    max: usize,
+) -> arbitrary::Result<HashMap<String, String>> {
+    let count = u.int_in_range::<usize>(0..=max)?;
+    let mut items = HashMap::with_capacity(count);
+    for _ in 0..count {
+        items.insert(small_string(u)?, small_string(u)?);
+    }
+    Ok(items)
 }


### PR DESCRIPTION
## Summary
- add `small_string_vec` and `small_string_map` helpers for property-based tests
- use helpers in `MemoryEntity` and `MemoryRelationship` generators
- rename memory service property-test module to `prop_tests`

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_6852f66399748327ba70eb8e6020711a