### PR TITLE
style: Rename default_tag to default_label

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -2,8 +2,8 @@
 
 
 [memory]
-# Tag added to every new entity
-default_tag = "Memory"
+# Label added to every new entity
+default_label = "Memory"
 default_relationships = true
 additional_relationships = []
 default_labels = true

--- a/crates/mm-core/src/operations/create_entity.rs
+++ b/crates/mm-core/src/operations/create_entity.rs
@@ -64,7 +64,7 @@ mod tests {
         let service = MemoryService::new(
             mock_repo,
             MemoryConfig {
-                default_tag: None,
+                default_label: None,
                 default_labels: false,
                 ..MemoryConfig::default()
             },
@@ -92,7 +92,7 @@ mod tests {
         let service = MemoryService::new(
             mock_repo,
             MemoryConfig {
-                default_tag: None,
+                default_label: None,
                 default_labels: false,
                 ..MemoryConfig::default()
             },
@@ -128,7 +128,7 @@ mod tests {
         let service = MemoryService::new(
             mock_repo,
             MemoryConfig {
-                default_tag: None,
+                default_label: None,
                 default_labels: false,
                 ..MemoryConfig::default()
             },
@@ -157,7 +157,7 @@ mod tests {
         let service = MemoryService::new(
             mock_repo,
             MemoryConfig {
-                default_tag: None,
+                default_label: None,
                 default_labels: false,
                 ..MemoryConfig::default()
             },

--- a/crates/mm-memory-neo4j/src/lib.rs
+++ b/crates/mm-memory-neo4j/src/lib.rs
@@ -40,7 +40,7 @@ pub mod adapters;
 // Re-export main types for convenience
 pub use adapters::neo4j::{Neo4jConfig, Neo4jRepository};
 pub use mm_memory::{
-    DEFAULT_MEMORY_TAG, MemoryConfig, MemoryEntity, MemoryError, MemoryRepository, MemoryResult,
+    DEFAULT_MEMORY_LABEL, MemoryConfig, MemoryEntity, MemoryError, MemoryRepository, MemoryResult,
     MemoryService, ValidationError,
 };
 

--- a/crates/mm-memory-neo4j/tests/neo4j_integration.rs
+++ b/crates/mm-memory-neo4j/tests/neo4j_integration.rs
@@ -26,7 +26,7 @@ async fn test_find_nonexistent_entity() {
     let service = create_neo4j_service(
         config,
         MemoryConfig {
-            default_tag: Some("TestFindNone".to_string()),
+            default_label: Some("TestFindNone".to_string()),
             default_relationships: true,
             additional_relationships: std::collections::HashSet::default(),
             default_labels: true,
@@ -55,7 +55,7 @@ async fn test_create_and_find_entity() {
     let service = create_neo4j_service(
         config,
         MemoryConfig {
-            default_tag: Some("TestCreate".to_string()),
+            default_label: Some("TestCreate".to_string()),
             default_relationships: true,
             additional_relationships: std::collections::HashSet::default(),
             default_labels: true,
@@ -111,7 +111,7 @@ async fn test_validation_errors() {
     let service = create_neo4j_service(
         config,
         MemoryConfig {
-            default_tag: Some("TestValidation".to_string()),
+            default_label: Some("TestValidation".to_string()),
             default_relationships: true,
             additional_relationships: std::collections::HashSet::default(),
             default_labels: true,
@@ -156,7 +156,7 @@ async fn test_set_observations() {
     let service = create_neo4j_service(
         config,
         MemoryConfig {
-            default_tag: Some("TestSet".to_string()),
+            default_label: Some("TestSet".to_string()),
             default_relationships: true,
             additional_relationships: std::collections::HashSet::default(),
             default_labels: true,
@@ -203,7 +203,7 @@ async fn test_add_and_remove_observations() {
     let service = create_neo4j_service(
         config,
         MemoryConfig {
-            default_tag: Some("TestAddRemove".to_string()),
+            default_label: Some("TestAddRemove".to_string()),
             default_relationships: true,
             additional_relationships: std::collections::HashSet::default(),
             default_labels: true,
@@ -271,7 +271,7 @@ async fn test_create_relationship() {
     let service = create_neo4j_service(
         config,
         MemoryConfig {
-            default_tag: Some("RelationshipTest".to_string()),
+            default_label: Some("RelationshipTest".to_string()),
             default_relationships: true,
             additional_relationships: std::collections::HashSet::default(),
             default_labels: true,

--- a/crates/mm-memory/src/config.rs
+++ b/crates/mm-memory/src/config.rs
@@ -4,9 +4,9 @@ use std::collections::HashSet;
 /// Configuration options for memory service behavior
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct MemoryConfig {
-    /// Optional tag automatically added to every created entity
+    /// Optional label automatically added to every created entity
     #[serde(default)]
-    pub default_tag: Option<String>,
+    pub default_label: Option<String>,
 
     /// Enforce use of default relationships
     #[serde(default = "MemoryConfig::default_true")]
@@ -25,8 +25,8 @@ pub struct MemoryConfig {
     pub additional_labels: HashSet<String>,
 }
 
-/// Default tag used when none is specified in the configuration
-pub const DEFAULT_MEMORY_TAG: &str = "Memory";
+/// Default label used when none is specified in the configuration
+pub const DEFAULT_MEMORY_LABEL: &str = "Memory";
 
 /// Default set of allowed relationship names
 pub const DEFAULT_RELATIONSHIPS: &[&str] = &[
@@ -120,7 +120,7 @@ impl MemoryConfig {
 impl Default for MemoryConfig {
     fn default() -> Self {
         Self {
-            default_tag: Some(DEFAULT_MEMORY_TAG.to_string()),
+            default_label: Some(DEFAULT_MEMORY_LABEL.to_string()),
             default_relationships: true,
             additional_relationships: HashSet::default(),
             default_labels: true,

--- a/crates/mm-memory/src/lib.rs
+++ b/crates/mm-memory/src/lib.rs
@@ -9,7 +9,7 @@ pub mod validation_error;
 pub mod value;
 
 pub use config::{DEFAULT_LABELS, DEFAULT_RELATIONSHIPS};
-pub use config::{DEFAULT_MEMORY_TAG, MemoryConfig};
+pub use config::{DEFAULT_MEMORY_LABEL, MemoryConfig};
 pub use entity::MemoryEntity;
 pub use error::{MemoryError, MemoryResult};
 pub use relationship::MemoryRelationship;

--- a/crates/mm-memory/src/service.rs
+++ b/crates/mm-memory/src/service.rs
@@ -44,9 +44,9 @@ where
 
         for entity in entities {
             let mut tagged = entity.clone();
-            if let Some(tag) = &self.config.default_tag {
-                if !tagged.labels.contains(tag) {
-                    tagged.labels.push(tag.clone());
+            if let Some(label) = &self.config.default_label {
+                if !tagged.labels.contains(label) {
+                    tagged.labels.push(label.clone());
                 }
             }
 
@@ -59,9 +59,9 @@ where
             }
             if self.config.default_labels {
                 for label in &tagged.labels {
-                    let allowed_default_tag =
-                        self.config.default_tag.as_deref() == Some(label.as_str());
-                    if !allowed_default_tag
+                    let allowed_default_label =
+                        self.config.default_label.as_deref() == Some(label.as_str());
+                    if !allowed_default_label
                         && !DEFAULT_LABELS.contains(&label.as_str())
                         && !self.config.additional_labels.contains(label)
                     {
@@ -180,7 +180,7 @@ mod tests {
     use std::collections::{HashMap, HashSet};
 
     #[tokio::test]
-    async fn test_default_tag_added() {
+    async fn test_default_label_added() {
         let mut mock = MockMemoryRepository::new();
         mock.expect_create_entities()
             .withf(|e| e.len() == 1 && e[0].labels.contains(&"Memory".to_string()))
@@ -189,7 +189,7 @@ mod tests {
         let service = MemoryService::new(
             mock,
             MemoryConfig {
-                default_tag: Some("Memory".to_string()),
+                default_label: Some("Memory".to_string()),
                 default_relationships: true,
                 additional_relationships: HashSet::default(),
                 default_labels: false,
@@ -211,7 +211,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_no_default_tag() {
+    async fn test_no_default_label() {
         let mut mock = MockMemoryRepository::new();
         mock.expect_create_entities()
             .withf(|e| e.len() == 1 && !e[0].labels.contains(&"Memory".to_string()))
@@ -220,7 +220,7 @@ mod tests {
         let service = MemoryService::new(
             mock,
             MemoryConfig {
-                default_tag: None,
+                default_label: None,
                 default_relationships: true,
                 additional_relationships: HashSet::default(),
                 default_labels: false,
@@ -242,7 +242,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_empty_labels_adds_default_tag() {
+    async fn test_empty_labels_adds_default_label() {
         let mut mock = MockMemoryRepository::new();
         mock.expect_create_entities()
             .withf(|e| {
@@ -255,7 +255,7 @@ mod tests {
         let service = MemoryService::new(
             mock,
             MemoryConfig {
-                default_tag: Some("Memory".to_string()),
+                default_label: Some("Memory".to_string()),
                 default_relationships: true,
                 additional_relationships: HashSet::default(),
                 default_labels: false,
@@ -278,14 +278,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_empty_labels_without_default_tag_fails() {
+    async fn test_empty_labels_without_default_label_fails() {
         let mut mock = MockMemoryRepository::new();
         mock.expect_create_entities().never();
 
         let service = MemoryService::new(
             mock,
             MemoryConfig {
-                default_tag: None,
+                default_label: None,
                 default_relationships: true,
                 additional_relationships: HashSet::default(),
                 default_labels: false,
@@ -312,7 +312,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_default_tag_allowed_with_label_validation() {
+    async fn test_default_label_allowed_with_label_validation() {
         let mut mock = MockMemoryRepository::new();
         mock.expect_create_entities()
             .withf(|e| e.len() == 1 && e[0].labels == ["Custom".to_string()])
@@ -321,7 +321,7 @@ mod tests {
         let service = MemoryService::new(
             mock,
             MemoryConfig {
-                default_tag: Some("Custom".to_string()),
+                default_label: Some("Custom".to_string()),
                 default_relationships: true,
                 additional_relationships: HashSet::default(),
                 default_labels: true,
@@ -351,7 +351,7 @@ mod tests {
         let service = MemoryService::new(
             mock,
             MemoryConfig {
-                default_tag: None,
+                default_label: None,
                 default_relationships: true,
                 additional_relationships: HashSet::default(),
                 default_labels: true,
@@ -384,7 +384,7 @@ mod tests {
         let service = MemoryService::new(
             mock,
             MemoryConfig {
-                default_tag: None,
+                default_label: None,
                 default_relationships: true,
                 additional_relationships: HashSet::default(),
                 default_labels: true,
@@ -413,7 +413,7 @@ mod tests {
         let service = MemoryService::new(
             mock,
             MemoryConfig {
-                default_tag: None,
+                default_label: None,
                 default_relationships: true,
                 additional_relationships: HashSet::default(),
                 default_labels: true,
@@ -449,7 +449,7 @@ mod tests {
         let service = MemoryService::new(
             mock,
             MemoryConfig {
-                default_tag: Some("Memory".to_string()),
+                default_label: Some("Memory".to_string()),
                 default_relationships: true,
                 additional_relationships: HashSet::default(),
                 default_labels: false,
@@ -477,7 +477,7 @@ mod tests {
         let service = MemoryService::new(
             mock,
             MemoryConfig {
-                default_tag: None,
+                default_label: None,
                 default_relationships: true,
                 additional_relationships: HashSet::default(),
                 default_labels: true,
@@ -561,7 +561,7 @@ mod tests {
                     Err(_) => return Ok(()),
                 };
                 if DEFAULT_LABELS.contains(&label.as_str())
-                    || label == MemoryConfig::default().default_tag.clone().unwrap()
+                    || label == MemoryConfig::default().default_label.clone().unwrap()
                 {
                     label.push_str("_x");
                 }

--- a/crates/mm-server/src/config.rs
+++ b/crates/mm-server/src/config.rs
@@ -70,7 +70,7 @@ mod tests {
     fn test_load_from_string() {
         let config_content = r#"
 [memory]
-default_tag = "TestTag"
+default_label = "TestTag"
 [neo4j]
 uri = "neo4j://testhost:7687"
 username = "test_user"
@@ -85,7 +85,7 @@ password = "test_password"
         assert_eq!(config.neo4j.uri, "neo4j://testhost:7687");
         assert_eq!(config.neo4j.username, "test_user");
         assert_eq!(config.neo4j.password, "test_password");
-        assert_eq!(config.memory.default_tag, Some("TestTag".to_string()));
+        assert_eq!(config.memory.default_label, Some("TestTag".to_string()));
         assert!(config.memory.default_relationships);
     }
 
@@ -98,7 +98,7 @@ password = "test_password"
                 password: "test_conversion_password".to_string(),
             },
             memory: MemoryConfig {
-                default_tag: None,
+                default_label: None,
                 default_relationships: true,
                 additional_relationships: std::collections::HashSet::default(),
                 default_labels: true,


### PR DESCRIPTION
## Summary
- update config field name from `default_tag` to `default_label`
- adjust defaults and tests to use the new label field
- rename constant to `DEFAULT_MEMORY_LABEL`

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_685467d14d7c8327a33d94cb444a4177