### PR TITLE
feat(memory): Add relationship retrieval to MemoryEntity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1385,6 +1385,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "time",
  "tokio",
  "tracing",
 ]

--- a/crates/mm-core/src/operations/create_entity.rs
+++ b/crates/mm-core/src/operations/create_entity.rs
@@ -77,6 +77,7 @@ mod tests {
                 labels: vec!["Test".to_string()],
                 observations: vec![],
                 properties: HashMap::default(),
+                relationships: Vec::new(),
             }],
         };
 
@@ -105,6 +106,7 @@ mod tests {
                 labels: vec!["Test".to_string()],
                 observations: vec![],
                 properties: HashMap::default(),
+                relationships: Vec::new(),
             }],
         };
 
@@ -141,6 +143,7 @@ mod tests {
                 labels: vec!["Test".to_string()],
                 observations: vec![],
                 properties: HashMap::default(),
+                relationships: Vec::new(),
             }],
         };
 
@@ -171,12 +174,14 @@ mod tests {
                     labels: vec![],
                     observations: vec![],
                     properties: HashMap::default(),
+                    relationships: Vec::new(),
                 },
                 MemoryEntity {
                     name: "valid:entity".to_string(),
                     labels: vec![],
                     observations: vec![],
                     properties: HashMap::default(),
+                    relationships: Vec::new(),
                 },
             ],
         };

--- a/crates/mm-core/src/operations/create_entity.rs
+++ b/crates/mm-core/src/operations/create_entity.rs
@@ -50,7 +50,6 @@ mod tests {
     use super::*;
     use mm_memory::ValidationErrorKind;
     use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
-    use std::collections::HashMap;
     use std::sync::Arc;
 
     #[tokio::test]
@@ -75,9 +74,7 @@ mod tests {
             entities: vec![MemoryEntity {
                 name: "test:entity".to_string(),
                 labels: vec!["Test".to_string()],
-                observations: vec![],
-                properties: HashMap::default(),
-                relationships: Vec::new(),
+                ..Default::default()
             }],
         };
 
@@ -104,9 +101,7 @@ mod tests {
             entities: vec![MemoryEntity {
                 name: "".to_string(),
                 labels: vec!["Test".to_string()],
-                observations: vec![],
-                properties: HashMap::default(),
-                relationships: Vec::new(),
+                ..Default::default()
             }],
         };
 
@@ -141,9 +136,7 @@ mod tests {
             entities: vec![MemoryEntity {
                 name: "test:entity".to_string(),
                 labels: vec!["Test".to_string()],
-                observations: vec![],
-                properties: HashMap::default(),
-                relationships: Vec::new(),
+                ..Default::default()
             }],
         };
 
@@ -171,17 +164,11 @@ mod tests {
             entities: vec![
                 MemoryEntity {
                     name: "".to_string(),
-                    labels: vec![],
-                    observations: vec![],
-                    properties: HashMap::default(),
-                    relationships: Vec::new(),
+                    ..Default::default()
                 },
                 MemoryEntity {
                     name: "valid:entity".to_string(),
-                    labels: vec![],
-                    observations: vec![],
-                    properties: HashMap::default(),
-                    relationships: Vec::new(),
+                    ..Default::default()
                 },
             ],
         };

--- a/crates/mm-core/src/operations/get_entity.rs
+++ b/crates/mm-core/src/operations/get_entity.rs
@@ -47,7 +47,6 @@ mod tests {
     use super::*;
     use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository, ValidationErrorKind};
     use mockall::predicate::*;
-    use std::collections::HashMap;
     use std::sync::Arc;
 
     #[tokio::test]
@@ -56,9 +55,7 @@ mod tests {
         let entity = MemoryEntity {
             name: "test:entity".to_string(),
             labels: vec!["Test".to_string()],
-            observations: vec![],
-            properties: HashMap::default(),
-            relationships: Vec::new(),
+            ..Default::default()
         };
 
         mock_repo

--- a/crates/mm-core/src/operations/get_entity.rs
+++ b/crates/mm-core/src/operations/get_entity.rs
@@ -58,6 +58,7 @@ mod tests {
             labels: vec!["Test".to_string()],
             observations: vec![],
             properties: HashMap::default(),
+            relationships: Vec::new(),
         };
 
         mock_repo

--- a/crates/mm-memory-neo4j/src/adapters/neo4j.rs
+++ b/crates/mm-memory-neo4j/src/adapters/neo4j.rs
@@ -97,20 +97,21 @@ impl Neo4jRepository {
                             return Err(MemoryError::runtime_error(
                                 "Required field 'from' is null in relationship".to_string(),
                             ));
-                        },
+                        }
                         Err(e) => {
                             return Err(MemoryError::runtime_error_with_source(
                                 "Failed to get required 'from' field from relationship".to_string(),
                                 e,
                             ));
-                        },
+                        }
                         Ok(other) => {
                             return Err(MemoryError::runtime_error(format!(
-                                "Expected string for required 'from' field, got: {:?}", other
+                                "Expected string for required 'from' field, got: {:?}",
+                                other
                             )));
                         }
                     };
-                    
+
                     // Extract to (required field)
                     let to = match rel_map.get("to") {
                         Ok(neo4rs::BoltType::String(s)) => s.to_string(),
@@ -118,20 +119,21 @@ impl Neo4jRepository {
                             return Err(MemoryError::runtime_error(
                                 "Required field 'to' is null in relationship".to_string(),
                             ));
-                        },
+                        }
                         Err(e) => {
                             return Err(MemoryError::runtime_error_with_source(
                                 "Failed to get required 'to' field from relationship".to_string(),
                                 e,
                             ));
-                        },
+                        }
                         Ok(other) => {
                             return Err(MemoryError::runtime_error(format!(
-                                "Expected string for required 'to' field, got: {:?}", other
+                                "Expected string for required 'to' field, got: {:?}",
+                                other
                             )));
                         }
                     };
-                    
+
                     // Extract name (required field)
                     let name = match rel_map.get("name") {
                         Ok(neo4rs::BoltType::String(s)) => s.to_string(),
@@ -139,20 +141,21 @@ impl Neo4jRepository {
                             return Err(MemoryError::runtime_error(
                                 "Required field 'name' is null in relationship".to_string(),
                             ));
-                        },
+                        }
                         Err(e) => {
                             return Err(MemoryError::runtime_error_with_source(
                                 "Failed to get required 'name' field from relationship".to_string(),
                                 e,
                             ));
-                        },
+                        }
                         Ok(other) => {
                             return Err(MemoryError::runtime_error(format!(
-                                "Expected string for required 'name' field, got: {:?}", other
+                                "Expected string for required 'name' field, got: {:?}",
+                                other
                             )));
                         }
                     };
-                    
+
                     // Extract properties (optional)
                     let mut properties = HashMap::new();
                     if let Ok(neo4rs::BoltType::Map(props_map)) = rel_map.get("properties") {
@@ -160,20 +163,29 @@ impl Neo4jRepository {
                             match bolt_to_memory_value(value.clone()) {
                                 Ok(memory_value) => {
                                     properties.insert(key.to_string(), memory_value);
-                                },
+                                }
                                 Err(e) => {
                                     // Property conversion errors are still logged but don't fail the whole operation
                                     tracing::error!(
-                                        "Failed to convert property '{}' in relationship {}-[{}]->{}: {}", 
-                                        key, from, name, to, e
+                                        "Failed to convert property '{}' in relationship {}-[{}]->{}: {}",
+                                        key,
+                                        from,
+                                        name,
+                                        to,
+                                        e
                                     );
                                 }
                             }
                         }
                     } else {
-                        tracing::debug!("No properties found for relationship {}-[{}]->{}", from, name, to);
+                        tracing::debug!(
+                            "No properties found for relationship {}-[{}]->{}",
+                            from,
+                            name,
+                            to
+                        );
                     }
-                    
+
                     relationships.push(MemoryRelationship {
                         from,
                         to,
@@ -185,16 +197,18 @@ impl Neo4jRepository {
                     continue;
                 } else {
                     return Err(MemoryError::runtime_error(format!(
-                        "Expected Map for relationship, got: {:?}", rel_item
+                        "Expected Map for relationship, got: {:?}",
+                        rel_item
                     )));
                 }
             }
         } else {
             return Err(MemoryError::runtime_error(format!(
-                "Expected List for relationships, got: {:?}", bolt
+                "Expected List for relationships, got: {:?}",
+                bolt
             )));
         }
-        
+
         Ok(relationships)
     }
 }

--- a/crates/mm-memory-neo4j/src/adapters/neo4j.rs
+++ b/crates/mm-memory-neo4j/src/adapters/neo4j.rs
@@ -117,7 +117,7 @@ impl MemoryRepository for Neo4jRepository {
             "MATCH (n {name: $name}) \n\
              OPTIONAL MATCH (n)-[r]-() \n\
              WITH n, collect({from: startNode(r).name, to: endNode(r).name, name: type(r), properties: properties(r)}) as rels \n\
-             RETURN n, apoc.convert.toJson(rels) as rels_json"
+             RETURN n, coalesce(apoc.convert.toJson(rels), '[]') as rels_json"
                 .to_string(),
         )
         .param("name", name.to_string());

--- a/crates/mm-memory-neo4j/tests/neo4j_integration.rs
+++ b/crates/mm-memory-neo4j/tests/neo4j_integration.rs
@@ -72,6 +72,7 @@ async fn test_create_and_find_entity() {
         labels: vec!["Example".to_string()],
         observations: vec!["This is a test entity for creation".to_string()],
         properties: props,
+        relationships: Vec::new(),
     };
 
     // Test that entity creation doesn't error
@@ -131,6 +132,7 @@ async fn test_validation_errors() {
         labels: vec![],
         observations: vec!["This entity has no labels".to_string()],
         properties: HashMap::default(),
+        relationships: Vec::new(),
     };
 
     let result = service.create_entities(std::slice::from_ref(&entity)).await;
@@ -172,6 +174,7 @@ async fn test_set_observations() {
         labels: vec!["Example".to_string()],
         observations: vec!["initial".to_string()],
         properties: HashMap::default(),
+        relationships: Vec::new(),
     };
 
     service
@@ -219,6 +222,7 @@ async fn test_add_and_remove_observations() {
         labels: vec!["Example".to_string()],
         observations: vec!["obs1".to_string(), "obs2".to_string()],
         properties: HashMap::default(),
+        relationships: Vec::new(),
     };
 
     service
@@ -286,12 +290,14 @@ async fn test_create_relationship() {
         labels: vec!["Example".to_string()],
         observations: vec![],
         properties: HashMap::default(),
+        relationships: Vec::new(),
     };
     let b = MemoryEntity {
         name: "rel:b".to_string(),
         labels: vec!["Example".to_string()],
         observations: vec![],
         properties: HashMap::default(),
+        relationships: Vec::new(),
     };
 
     service
@@ -314,4 +320,20 @@ async fn test_create_relationship() {
         .create_relationships(std::slice::from_ref(&rel))
         .await
         .unwrap();
+
+    let fetched_a = service.find_entity_by_name("rel:a").await.unwrap().unwrap();
+    assert!(
+        fetched_a
+            .relationships
+            .iter()
+            .any(|r| r.from == "rel:a" && r.to == "rel:b" && r.name == "relates_to")
+    );
+
+    let fetched_b = service.find_entity_by_name("rel:b").await.unwrap().unwrap();
+    assert!(
+        fetched_b
+            .relationships
+            .iter()
+            .any(|r| r.from == "rel:a" && r.to == "rel:b" && r.name == "relates_to")
+    );
 }

--- a/crates/mm-memory-neo4j/tests/neo4j_integration.rs
+++ b/crates/mm-memory-neo4j/tests/neo4j_integration.rs
@@ -72,7 +72,7 @@ async fn test_create_and_find_entity() {
         labels: vec!["Example".to_string()],
         observations: vec!["This is a test entity for creation".to_string()],
         properties: props,
-        relationships: Vec::new(),
+        ..Default::default()
     };
 
     // Test that entity creation doesn't error
@@ -129,10 +129,8 @@ async fn test_validation_errors() {
     // Test entity with no labels
     let entity = MemoryEntity {
         name: "test:entity:no_labels".to_string(),
-        labels: vec![],
         observations: vec!["This entity has no labels".to_string()],
-        properties: HashMap::default(),
-        relationships: Vec::new(),
+        ..Default::default()
     };
 
     let result = service.create_entities(std::slice::from_ref(&entity)).await;
@@ -173,8 +171,7 @@ async fn test_set_observations() {
         name: entity_name.to_string(),
         labels: vec!["Example".to_string()],
         observations: vec!["initial".to_string()],
-        properties: HashMap::default(),
-        relationships: Vec::new(),
+        ..Default::default()
     };
 
     service
@@ -221,8 +218,7 @@ async fn test_add_and_remove_observations() {
         name: entity_name.to_string(),
         labels: vec!["Example".to_string()],
         observations: vec!["obs1".to_string(), "obs2".to_string()],
-        properties: HashMap::default(),
-        relationships: Vec::new(),
+        ..Default::default()
     };
 
     service
@@ -288,16 +284,12 @@ async fn test_create_relationship() {
     let a = MemoryEntity {
         name: "rel:a".to_string(),
         labels: vec!["Example".to_string()],
-        observations: vec![],
-        properties: HashMap::default(),
-        relationships: Vec::new(),
+        ..Default::default()
     };
     let b = MemoryEntity {
         name: "rel:b".to_string(),
         labels: vec!["Example".to_string()],
-        observations: vec![],
-        properties: HashMap::default(),
-        relationships: Vec::new(),
+        ..Default::default()
     };
 
     service

--- a/crates/mm-memory/src/entity.rs
+++ b/crates/mm-memory/src/entity.rs
@@ -2,6 +2,7 @@ use rust_mcp_sdk::macros::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use crate::relationship::MemoryRelationship;
 use crate::value::MemoryValue;
 
 /// Memory entity representing a node in the knowledge graph
@@ -16,4 +17,7 @@ pub struct MemoryEntity {
     /// Additional key-value properties
     #[serde(default)]
     pub properties: HashMap<String, MemoryValue>,
+    /// Relationships connected to the entity
+    #[serde(default)]
+    pub relationships: Vec<MemoryRelationship>,
 }

--- a/crates/mm-memory/src/entity.rs
+++ b/crates/mm-memory/src/entity.rs
@@ -6,7 +6,7 @@ use crate::relationship::MemoryRelationship;
 use crate::value::MemoryValue;
 
 /// Memory entity representing a node in the knowledge graph
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, JsonSchema)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, JsonSchema, Default)]
 pub struct MemoryEntity {
     /// Unique name of the entity
     pub name: String,

--- a/crates/mm-memory/src/service.rs
+++ b/crates/mm-memory/src/service.rs
@@ -200,9 +200,7 @@ mod tests {
         let entity = MemoryEntity {
             name: "test:entity".to_string(),
             labels: vec!["Test".to_string()],
-            observations: vec![],
-            properties: std::collections::HashMap::default(),
-            relationships: Vec::new(),
+            ..Default::default()
         };
 
         let result = service
@@ -232,9 +230,7 @@ mod tests {
         let entity = MemoryEntity {
             name: "test:entity".to_string(),
             labels: vec!["Test".to_string()],
-            observations: vec![],
-            properties: std::collections::HashMap::default(),
-            relationships: Vec::new(),
+            ..Default::default()
         };
 
         let result = service
@@ -269,9 +265,7 @@ mod tests {
         let entity = MemoryEntity {
             name: "test:entity".to_string(),
             labels: vec![],
-            observations: vec![],
-            properties: std::collections::HashMap::default(),
-            relationships: Vec::new(),
+            ..Default::default()
         };
 
         let errors = service
@@ -300,9 +294,7 @@ mod tests {
         let entity = MemoryEntity {
             name: "test:entity".to_string(),
             labels: vec![],
-            observations: vec![],
-            properties: std::collections::HashMap::default(),
-            relationships: Vec::new(),
+            ..Default::default()
         };
 
         let result = service
@@ -337,9 +329,7 @@ mod tests {
         let entity = MemoryEntity {
             name: "test:entity".to_string(),
             labels: vec![],
-            observations: vec![],
-            properties: HashMap::default(),
-            relationships: Vec::new(),
+            ..Default::default()
         };
 
         let result = service
@@ -368,9 +358,7 @@ mod tests {
         let entity = MemoryEntity {
             name: "test:entity".to_string(),
             labels: vec!["Unknown".to_string()],
-            observations: vec![],
-            properties: HashMap::default(),
-            relationships: Vec::new(),
+            ..Default::default()
         };
 
         let result = service
@@ -467,9 +455,7 @@ mod tests {
         let entity = MemoryEntity {
             name: "test:entity".to_string(),
             labels: vec!["Test".to_string()],
-            observations: vec![],
-            properties: HashMap::default(),
-            relationships: Vec::new(),
+            ..Default::default()
         };
 
         let result = service.create_entities(std::slice::from_ref(&entity)).await;
@@ -517,9 +503,8 @@ mod tests {
         let entity = MemoryEntity {
             name: "a".to_string(),
             labels: vec!["Test".to_string()],
-            observations: vec![],
-            properties: HashMap::default(),
             relationships: vec![relationship.clone()],
+            ..Default::default()
         };
 
         let mut mock = MockMemoryRepository::new();

--- a/crates/mm-memory/src/test_helpers.rs
+++ b/crates/mm-memory/src/test_helpers.rs
@@ -40,7 +40,7 @@ pub fn prop_random_entity(
         labels,
         observations,
         properties,
-        relationships: Vec::new(),
+        ..Default::default()
     })
 }
 

--- a/crates/mm-memory/src/test_helpers.rs
+++ b/crates/mm-memory/src/test_helpers.rs
@@ -40,6 +40,7 @@ pub fn prop_random_entity(
         labels,
         observations,
         properties,
+        relationships: Vec::new(),
     })
 }
 

--- a/crates/mm-server/src/mcp/create_entity.rs
+++ b/crates/mm-server/src/mcp/create_entity.rs
@@ -61,6 +61,7 @@ mod tests {
                 labels: vec!["Test".to_string()],
                 observations: vec![],
                 properties: HashMap::default(),
+                relationships: Vec::new(),
             }],
         };
 
@@ -71,7 +72,8 @@ mod tests {
                 "name": "test:entity",
                 "labels": ["Test"],
                 "observations": [],
-                "properties": {}
+                "properties": {},
+                "relationships": []
             }
         ]);
         assert_eq!(text, expected.to_string());
@@ -92,6 +94,7 @@ mod tests {
                 labels: vec!["Test".to_string()],
                 observations: vec![],
                 properties: HashMap::default(),
+                relationships: Vec::new(),
             }],
         };
 

--- a/crates/mm-server/src/mcp/create_entity.rs
+++ b/crates/mm-server/src/mcp/create_entity.rs
@@ -36,7 +36,6 @@ mod tests {
     use super::*;
     use mm_core::Ports;
     use mm_memory::{MemoryConfig, MemoryError, MemoryService, MockMemoryRepository};
-    use std::collections::HashMap;
     use std::sync::Arc;
 
     #[tokio::test]
@@ -59,9 +58,7 @@ mod tests {
             entities: vec![MemoryEntity {
                 name: "test:entity".to_string(),
                 labels: vec!["Test".to_string()],
-                observations: vec![],
-                properties: HashMap::default(),
-                relationships: Vec::new(),
+                ..Default::default()
             }],
         };
 
@@ -92,9 +89,7 @@ mod tests {
             entities: vec![MemoryEntity {
                 name: "test:entity".to_string(),
                 labels: vec!["Test".to_string()],
-                observations: vec![],
-                properties: HashMap::default(),
-                relationships: Vec::new(),
+                ..Default::default()
             }],
         };
 

--- a/crates/mm-server/src/mcp/get_entity.rs
+++ b/crates/mm-server/src/mcp/get_entity.rs
@@ -55,6 +55,7 @@ mod tests {
             labels: vec!["Test".to_string()],
             observations: vec![],
             properties: HashMap::default(),
+            relationships: Vec::new(),
         };
 
         let mut mock = MockMemoryRepository::new();
@@ -73,6 +74,7 @@ mod tests {
         let text = result.content[0].as_text_content().unwrap().text.clone();
         let value: Value = serde_json::from_str(&text).unwrap();
         assert_eq!(value["name"], "test:entity");
+        assert!(value["relationships"].as_array().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/crates/mm-server/src/mcp/get_entity.rs
+++ b/crates/mm-server/src/mcp/get_entity.rs
@@ -45,7 +45,6 @@ mod tests {
     use mm_memory::{MemoryConfig, MemoryEntity, MemoryError, MemoryService, MockMemoryRepository};
     use mockall::predicate::*;
     use serde_json::Value;
-    use std::collections::HashMap;
     use std::sync::Arc;
 
     #[tokio::test]
@@ -53,9 +52,7 @@ mod tests {
         let entity = MemoryEntity {
             name: "test:entity".to_string(),
             labels: vec!["Test".to_string()],
-            observations: vec![],
-            properties: HashMap::default(),
-            relationships: Vec::new(),
+            ..Default::default()
         };
 
         let mut mock = MockMemoryRepository::new();

--- a/crates/mm-server/src/resources.rs
+++ b/crates/mm-server/src/resources.rs
@@ -85,6 +85,7 @@ mod tests {
             labels: vec!["Test".to_string()],
             observations: vec![],
             properties: HashMap::default(),
+            relationships: Vec::new(),
         };
 
         let mut mock = MockMemoryRepository::new();

--- a/crates/mm-server/src/resources.rs
+++ b/crates/mm-server/src/resources.rs
@@ -75,7 +75,6 @@ mod tests {
     use super::*;
     use mm_memory::{MemoryConfig, MemoryEntity, MemoryService, MockMemoryRepository};
     use mockall::predicate::*;
-    use std::collections::HashMap;
     use std::sync::Arc;
 
     #[tokio::test]
@@ -83,9 +82,7 @@ mod tests {
         let entity = MemoryEntity {
             name: "test:entity".to_string(),
             labels: vec!["Test".to_string()],
-            observations: vec![],
-            properties: HashMap::default(),
-            relationships: Vec::new(),
+            ..Default::default()
         };
 
         let mut mock = MockMemoryRepository::new();


### PR DESCRIPTION
## Summary
- track relationships on `MemoryEntity`
- fetch relationships in neo4j queries
- adjust services and tools to return relationships
- extend unit and integration tests for relationship retrieval

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_685473db2628832782a9dd69fb435a3e