### PR TITLE
Implement direct MemoryValue <-> BoltType conversions

### DIFF
--- a/crates/mm-memory-neo4j/Cargo.toml
+++ b/crates/mm-memory-neo4j/Cargo.toml
@@ -13,6 +13,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 async-trait = { workspace = true }
 mm-memory = { path = "../mm-memory" }
+time = { workspace = true }
 
 [dev-dependencies]
 mockall = { workspace = true }

--- a/crates/mm-memory-neo4j/src/adapters/conversions.rs
+++ b/crates/mm-memory-neo4j/src/adapters/conversions.rs
@@ -1,0 +1,95 @@
+use std::collections::HashMap;
+
+use mm_memory::{MemoryError, MemoryValue};
+use neo4rs::BoltType;
+use time::format_description::well_known::Rfc3339;
+
+/// Convert a [`MemoryValue`] directly into a [`neo4rs::BoltType`].
+///
+/// This avoids the indirection through `serde_json::Value` when
+/// sending data to Neo4j.
+pub(crate) fn memory_value_to_bolt(
+    value: &MemoryValue,
+) -> Result<BoltType, MemoryError<neo4rs::Error>> {
+    Ok(match value {
+        MemoryValue::String(s) => s.clone().into(),
+        MemoryValue::Integer(i) => (*i).into(),
+        MemoryValue::Float(f) => (*f).into(),
+        MemoryValue::Boolean(b) => (*b).into(),
+        MemoryValue::Bytes(bytes) => bytes.clone().into(),
+        MemoryValue::List(items) => {
+            let bolt_items: Vec<BoltType> = items
+                .iter()
+                .map(memory_value_to_bolt)
+                .collect::<Result<_, _>>()?;
+            bolt_items.into()
+        }
+        MemoryValue::Date(d) => d.to_string().into(),
+        MemoryValue::Time(t) => t.to_string().into(),
+        MemoryValue::OffsetTime { time, offset } => {
+            let mut map: HashMap<String, BoltType> = HashMap::new();
+            map.insert("time".to_string(), time.to_string().into());
+            map.insert("offset".to_string(), offset.to_string().into());
+            map.into()
+        }
+        MemoryValue::DateTime(dt) => dt.format(&Rfc3339).map(|s| s.into()).map_err(|e| {
+            MemoryError::runtime_error_with_source("Invalid datetime".to_string(), e)
+        })?,
+        MemoryValue::LocalDateTime(dt) => dt.to_string().into(),
+        MemoryValue::Duration(d) => format!("{}", d.whole_nanoseconds()).into(),
+    })
+}
+
+/// Convert a [`neo4rs::BoltType`] directly into a [`MemoryValue`].
+///
+/// This is the inverse of [`memory_value_to_bolt`].
+pub(crate) fn bolt_to_memory_value(
+    bolt: BoltType,
+) -> Result<MemoryValue, MemoryError<neo4rs::Error>> {
+    Ok(match bolt {
+        BoltType::String(s) => MemoryValue::String(s.value),
+        BoltType::Integer(i) => MemoryValue::Integer(i.value),
+        BoltType::Float(f) => MemoryValue::Float(f.value),
+        BoltType::Boolean(b) => MemoryValue::Boolean(b.value),
+        BoltType::Bytes(b) => MemoryValue::Bytes(b.value.to_vec()),
+        BoltType::List(list) => MemoryValue::List(
+            list.value
+                .into_iter()
+                .map(bolt_to_memory_value)
+                .collect::<Result<Vec<MemoryValue>, _>>()?,
+        ),
+        BoltType::Map(map) => {
+            return Err(MemoryError::runtime_error(format!(
+                "Unsupported bolt type: Map({:?})",
+                map
+            )));
+        }
+        other => {
+            return Err(MemoryError::runtime_error(format!(
+                "Unsupported bolt type: {:?}",
+                other
+            )));
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_string() {
+        let v = MemoryValue::String("hello".to_string());
+        let bolt = memory_value_to_bolt(&v).unwrap();
+        let back = bolt_to_memory_value(bolt).unwrap();
+        assert_eq!(v, back);
+    }
+
+    #[test]
+    fn round_trip_list() {
+        let v = MemoryValue::List(vec![MemoryValue::Integer(1), MemoryValue::Boolean(true)]);
+        let bolt = memory_value_to_bolt(&v).unwrap();
+        let back = bolt_to_memory_value(bolt).unwrap();
+        assert_eq!(v, back);
+    }
+}

--- a/crates/mm-memory-neo4j/src/adapters/mod.rs
+++ b/crates/mm-memory-neo4j/src/adapters/mod.rs
@@ -1,1 +1,2 @@
+mod conversions;
 pub mod neo4j;

--- a/crates/mm-memory-neo4j/src/adapters/neo4j.rs
+++ b/crates/mm-memory-neo4j/src/adapters/neo4j.rs
@@ -1,8 +1,8 @@
+use crate::adapters::conversions::{bolt_to_memory_value, memory_value_to_bolt};
 use async_trait::async_trait;
 use neo4rs::{self, Graph, Node, Query};
 use serde_json;
 use std::collections::HashMap;
-use std::convert::TryInto;
 use tracing::instrument;
 
 use mm_memory::{
@@ -80,13 +80,7 @@ impl MemoryRepository for Neo4jRepository {
             let observations_json = serde_json::to_string(&entity.observations)?;
             props.insert("observations".to_string(), observations_json.into());
             for (k, v) in &entity.properties {
-                let json = serde_json::to_value(v)?;
-                let bolt: neo4rs::BoltType = json.try_into().map_err(|e| {
-                    MemoryError::runtime_error_with_source(
-                        "Failed to convert property".to_string(),
-                        e,
-                    )
-                })?;
+                let bolt = memory_value_to_bolt(v)?;
                 props.insert(k.clone(), bolt);
             }
 
@@ -176,21 +170,16 @@ impl MemoryRepository for Neo4jRepository {
 
             // Extract all other properties
             let mut properties: HashMap<String, MemoryValue> = HashMap::default();
-            let map: HashMap<String, serde_json::Value> = node.to().map_err(|e| {
-                MemoryError::runtime_error_with_source(
-                    "Failed to decode node properties".to_string(),
-                    e,
-                )
-            })?;
-            for (k, v) in map {
-                if k != "name" && k != "observations" {
-                    let mv = MemoryValue::try_from(v).map_err(|e| {
+            for key in node.keys() {
+                if key != "name" && key != "observations" {
+                    let bolt: neo4rs::BoltType = node.get(key).map_err(|e| {
                         MemoryError::runtime_error_with_source(
-                            "Failed to decode property".to_string(),
+                            "Failed to decode node properties".to_string(),
                             e,
                         )
                     })?;
-                    properties.insert(k, mv);
+                    let mv = bolt_to_memory_value(bolt)?;
+                    properties.insert(key.to_string(), mv);
                 }
             }
 
@@ -277,13 +266,7 @@ impl MemoryRepository for Neo4jRepository {
         for rel in relationships {
             let mut props: HashMap<String, neo4rs::BoltType> = HashMap::default();
             for (k, v) in &rel.properties {
-                let json = serde_json::to_value(v)?;
-                let bolt: neo4rs::BoltType = json.try_into().map_err(|e| {
-                    MemoryError::runtime_error_with_source(
-                        "Failed to convert relationship property".to_string(),
-                        e,
-                    )
-                })?;
+                let bolt = memory_value_to_bolt(v)?;
                 props.insert(k.clone(), bolt);
             }
 


### PR DESCRIPTION
## Summary
- add internal converters between `MemoryValue` and `neo4rs::BoltType`
- leverage these conversions inside the Neo4j adapter
- register new conversions module
- add unit tests for round‑trip conversions
- include `time` as a dependency for the adapter crate

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_68547a168fdc8327b793168fe439f75a