### PR TITLE
Add memory service kitchen sink test suite

### DIFF
--- a/crates/mm-memory-neo4j/Cargo.toml
+++ b/crates/mm-memory-neo4j/Cargo.toml
@@ -18,4 +18,4 @@ time = { workspace = true }
 [dev-dependencies]
 mockall = { workspace = true }
 tokio = { workspace = true, features = ["full", "test-util"] }
-mm-memory = { path = "../mm-memory", features = ["mock"] }
+mm-memory = { path = "../mm-memory", features = ["mock", "test-suite"] }

--- a/crates/mm-memory-neo4j/tests/neo4j_integration.rs
+++ b/crates/mm-memory-neo4j/tests/neo4j_integration.rs
@@ -1,5 +1,8 @@
+use mm_memory::test_suite::run_memory_service_test_suite;
 use mm_memory::{MemoryRelationship, MemoryValue};
-use mm_memory_neo4j::{MemoryConfig, MemoryEntity, MemoryError, Neo4jConfig, create_neo4j_service};
+use mm_memory_neo4j::{
+    MemoryConfig, MemoryEntity, MemoryError, Neo4jConfig, Neo4jRepository, create_neo4j_service,
+};
 use std::collections::HashMap;
 
 #[tokio::test]
@@ -328,4 +331,16 @@ async fn test_create_relationship() {
             .iter()
             .any(|r| r.from == "rel:a" && r.to == "rel:b" && r.name == "relates_to")
     );
+}
+
+#[tokio::test]
+async fn test_run_memory_service_suite() {
+    let config = Neo4jConfig {
+        uri: "neo4j://localhost:7688".to_string(),
+        username: "neo4j".to_string(),
+        password: "password".to_string(),
+    };
+
+    let repo = Neo4jRepository::new(config).await.unwrap();
+    run_memory_service_test_suite(repo).await.unwrap();
 }

--- a/crates/mm-memory/Cargo.toml
+++ b/crates/mm-memory/Cargo.toml
@@ -6,6 +6,7 @@ license = "MPL-2.0"
 
 [features]
 mock = ["mockall"]
+test-suite = []
 
 [dependencies]
 serde = { workspace = true }

--- a/crates/mm-memory/src/lib.rs
+++ b/crates/mm-memory/src/lib.rs
@@ -22,3 +22,6 @@ pub use value::MemoryValue;
 
 #[cfg(test)]
 pub mod test_helpers;
+
+#[cfg(any(test, feature = "test-suite"))]
+pub mod test_suite;

--- a/crates/mm-memory/src/test_suite.rs
+++ b/crates/mm-memory/src/test_suite.rs
@@ -1,0 +1,135 @@
+use crate::{
+    MemoryConfig, MemoryEntity, MemoryRelationship, MemoryRepository, MemoryService, MemoryValue,
+};
+use std::collections::{HashMap, HashSet};
+use time::OffsetDateTime;
+
+/// Run a comprehensive test suite against a `MemoryRepository` implementation.
+///
+/// This function creates a `MemoryService` with a fixed configuration and then
+/// exercises all service methods to verify correct behaviour. It can be reused
+/// with any repository implementation.
+pub async fn run_memory_service_test_suite<R>(
+    repository: R,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    R: MemoryRepository + Send + Sync + 'static,
+    R::Error: std::error::Error + Send + Sync + 'static,
+{
+    // Fixed configuration used for all tests
+    let config = MemoryConfig {
+        default_label: Some("TestSuite".to_string()),
+        default_relationships: true,
+        additional_relationships: HashSet::default(),
+        default_labels: true,
+        additional_labels: std::iter::once("Example".to_string()).collect(),
+    };
+
+    let service = MemoryService::new(repository, config);
+
+    // Generate unique names so repeated runs don't conflict
+    let unique = OffsetDateTime::now_utc().unix_timestamp_nanos();
+    let name_a = format!("test:suite:a:{unique}");
+    let name_b = format!("test:suite:b:{unique}");
+
+    // --- Entity creation (batch) ---
+    let mut props = HashMap::new();
+    props.insert("k".to_string(), MemoryValue::String("v".to_string()));
+    let entity_a = MemoryEntity {
+        name: name_a.clone(),
+        labels: vec!["Example".to_string()],
+        observations: vec!["first".to_string()],
+        properties: props,
+        ..Default::default()
+    };
+    let entity_b = MemoryEntity {
+        name: name_b.clone(),
+        labels: vec!["Example".to_string()],
+        ..Default::default()
+    };
+
+    let errs = service
+        .create_entities(&[entity_a.clone(), entity_b.clone()])
+        .await?;
+    assert!(errs.is_empty());
+
+    // Verify retrieval of entity and default label
+    let fetched_a = service
+        .find_entity_by_name(&name_a)
+        .await?
+        .expect("entity a should exist");
+    assert!(fetched_a.labels.contains(&"TestSuite".to_string()));
+    assert!(fetched_a.labels.contains(&"Example".to_string()));
+    assert_eq!(fetched_a.observations, ["first".to_string()]);
+    assert_eq!(
+        fetched_a.properties.get("k"),
+        Some(&MemoryValue::String("v".to_string()))
+    );
+
+    // --- Relationship creation ---
+    let rel = MemoryRelationship {
+        from: name_a.clone(),
+        to: name_b.clone(),
+        name: "relates_to".to_string(),
+        properties: HashMap::default(),
+    };
+    service.create_relationships(&[rel.clone()]).await?;
+
+    let fetched_a = service.find_entity_by_name(&name_a).await?.unwrap();
+    assert!(
+        fetched_a
+            .relationships
+            .iter()
+            .any(|r| r.from == name_a && r.to == name_b && r.name == "relates_to")
+    );
+
+    // --- Observation management ---
+    service
+        .set_observations(&name_a, &["one".to_string(), "two".to_string()])
+        .await?;
+    let after_set = service.find_entity_by_name(&name_a).await?.unwrap();
+    assert_eq!(after_set.observations, ["one", "two"]);
+
+    service
+        .add_observations(&name_a, &["three".to_string()])
+        .await?;
+    let after_add = service.find_entity_by_name(&name_a).await?.unwrap();
+    assert_eq!(after_add.observations, ["one", "two", "three"]);
+
+    service
+        .remove_observations(&name_a, &["two".to_string()])
+        .await?;
+    let after_remove = service.find_entity_by_name(&name_a).await?.unwrap();
+    assert_eq!(after_remove.observations, ["one", "three"]);
+
+    service.remove_all_observations(&name_a).await?;
+    let cleared = service.find_entity_by_name(&name_a).await?.unwrap();
+    assert!(cleared.observations.is_empty());
+
+    // --- Validation and error handling ---
+    let invalid = MemoryEntity::default();
+    let errs = service.create_entities(&[invalid]).await?;
+    assert!(!errs.is_empty());
+    assert!(service.find_entity_by_name("").await.is_err());
+
+    let bad_rel = MemoryRelationship {
+        from: name_a.clone(),
+        to: name_b.clone(),
+        name: "BadRel".to_string(),
+        properties: HashMap::default(),
+    };
+    let rel_errors = service.create_relationships(&[bad_rel]).await?;
+    assert!(!rel_errors.is_empty());
+
+    // --- Large batch create to exercise path ---
+    let extra: Vec<_> = (0..10)
+        .map(|i| MemoryEntity {
+            name: format!("test:suite:extra:{unique}:{i}"),
+            labels: vec!["Example".to_string()],
+            ..Default::default()
+        })
+        .collect();
+    service.create_entities(&extra).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a reusable `run_memory_service_test_suite` helper to `mm-memory`
- expose test suite via new `test-suite` crate feature
- run the suite against the Neo4j repository in integration tests

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_6854a68b5254832780d039ee5f282158