### PR TITLE
Implement generic property types

### DIFF
--- a/crates/mm-memory/src/entity.rs
+++ b/crates/mm-memory/src/entity.rs
@@ -27,5 +27,5 @@ where
     pub properties: P,
     /// Relationships connected to the entity
     #[serde(default)]
-    pub relationships: Vec<MemoryRelationship<P>>,
+    pub relationships: Vec<MemoryRelationship>,
 }

--- a/crates/mm-memory/src/entity.rs
+++ b/crates/mm-memory/src/entity.rs
@@ -7,7 +7,15 @@ use crate::value::MemoryValue;
 
 /// Memory entity representing a node in the knowledge graph
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, JsonSchema, Default)]
-pub struct MemoryEntity {
+pub struct MemoryEntity<P = HashMap<String, MemoryValue>>
+where
+    P: JsonSchema
+        + Into<HashMap<String, MemoryValue>>
+        + From<HashMap<String, MemoryValue>>
+        + Clone
+        + std::fmt::Debug
+        + Default,
+{
     /// Unique name of the entity
     pub name: String,
     /// Labels for categorizing the entity
@@ -16,8 +24,8 @@ pub struct MemoryEntity {
     pub observations: Vec<String>,
     /// Additional key-value properties
     #[serde(default)]
-    pub properties: HashMap<String, MemoryValue>,
+    pub properties: P,
     /// Relationships connected to the entity
     #[serde(default)]
-    pub relationships: Vec<MemoryRelationship>,
+    pub relationships: Vec<MemoryRelationship<P>>,
 }

--- a/crates/mm-memory/src/relationship.rs
+++ b/crates/mm-memory/src/relationship.rs
@@ -6,15 +6,7 @@ use crate::value::MemoryValue;
 
 /// Memory relationship representing an edge between entities
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, JsonSchema)]
-pub struct MemoryRelationship<P = HashMap<String, MemoryValue>>
-where
-    P: JsonSchema
-        + Into<HashMap<String, MemoryValue>>
-        + From<HashMap<String, MemoryValue>>
-        + Clone
-        + std::fmt::Debug
-        + Default,
-{
+pub struct MemoryRelationship {
     /// Name of the source entity
     pub from: String,
     /// Name of the target entity
@@ -23,5 +15,5 @@ where
     pub name: String,
     /// Additional key-value properties
     #[serde(default)]
-    pub properties: P,
+    pub properties: HashMap<String, MemoryValue>,
 }

--- a/crates/mm-memory/src/relationship.rs
+++ b/crates/mm-memory/src/relationship.rs
@@ -6,7 +6,15 @@ use crate::value::MemoryValue;
 
 /// Memory relationship representing an edge between entities
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, JsonSchema)]
-pub struct MemoryRelationship {
+pub struct MemoryRelationship<P = HashMap<String, MemoryValue>>
+where
+    P: JsonSchema
+        + Into<HashMap<String, MemoryValue>>
+        + From<HashMap<String, MemoryValue>>
+        + Clone
+        + std::fmt::Debug
+        + Default,
+{
     /// Name of the source entity
     pub from: String,
     /// Name of the target entity
@@ -15,5 +23,5 @@ pub struct MemoryRelationship {
     pub name: String,
     /// Additional key-value properties
     #[serde(default)]
-    pub properties: HashMap<String, MemoryValue>,
+    pub properties: P,
 }


### PR DESCRIPTION
## Summary
- make `MemoryEntity` and `MemoryRelationship` generic but keep repository interface unchanged
- convert property types within `MemoryService` before calling the repository
- revert generic changes in the Neo4j adapter

## Testing
- `cargo check`
- `just validate`


------
https://chatgpt.com/codex/tasks/task_e_6859fc4609048327af5daf2febaf9bb4