### PR TITLE
Add batch and query tools

### DIFF
--- a/crates/mm-core/src/lib.rs
+++ b/crates/mm-core/src/lib.rs
@@ -14,15 +14,19 @@ mod root;
 pub use error::{CoreError, CoreResult};
 pub use mm_memory::MemoryService;
 pub use operations::{
-    AddObservationsCommand, AddObservationsResult, CreateEntityCommand, CreateEntityResult,
-    CreateRelationshipCommand, CreateRelationshipResult, GetEntityCommand, GetEntityResult,
-    GetProjectContextCommand, GetProjectContextResult, ListProjectsCommand, ListProjectsResult,
-    ProjectFilter, RemoveAllObservationsCommand, RemoveAllObservationsResult,
-    RemoveObservationsCommand, RemoveObservationsResult, SetObservationsCommand,
-    SetObservationsResult, UpdateEntityCommand, UpdateEntityResult, UpdateRelationshipCommand,
-    UpdateRelationshipResult, add_observations, create_entity, create_relationship, get_entity,
-    get_project_context, list_projects, remove_all_observations, remove_observations,
-    set_observations, update_entity, update_relationship,
+    AddObservationsCommand, AddObservationsResult, CreateEntitiesCommand, CreateEntitiesResult,
+    CreateRelationshipsCommand, CreateRelationshipsResult, DeleteEntitiesCommand,
+    DeleteEntitiesResult, DeleteRelationshipsCommand, DeleteRelationshipsResult,
+    FindEntitiesByLabelsCommand, FindEntitiesByLabelsResult, FindEntitiesByLabelsResultType,
+    FindRelationshipsCommand, FindRelationshipsResult, FindRelationshipsResultType,
+    GetEntityCommand, GetEntityResult, GetProjectContextCommand, GetProjectContextResult,
+    ListProjectsCommand, ListProjectsResult, ProjectFilter, RemoveAllObservationsCommand,
+    RemoveAllObservationsResult, RemoveObservationsCommand, RemoveObservationsResult,
+    SetObservationsCommand, SetObservationsResult, UpdateEntityCommand, UpdateEntityResult,
+    UpdateRelationshipCommand, UpdateRelationshipResult, add_observations, create_entities,
+    create_relationships, delete_entities, delete_relationships, find_entities_by_labels,
+    find_relationships, get_entity, get_project_context, list_projects, remove_all_observations,
+    remove_observations, set_observations, update_entity, update_relationship,
 };
 pub use ports::Ports;
 pub use root::{Root, RootCollection};

--- a/crates/mm-core/src/operations/create_relationship.rs
+++ b/crates/mm-core/src/operations/create_relationship.rs
@@ -4,17 +4,17 @@ use mm_memory::{MemoryRelationship, MemoryRepository};
 use tracing::instrument;
 
 #[derive(Debug, Clone)]
-pub struct CreateRelationshipCommand {
+pub struct CreateRelationshipsCommand {
     pub relationships: Vec<MemoryRelationship>,
 }
 
-pub type CreateRelationshipResult<E> = CoreResult<(), E>;
+pub type CreateRelationshipsResult<E> = CoreResult<(), E>;
 
 #[instrument(skip(ports), fields(relationships_count = command.relationships.len()))]
-pub async fn create_relationship<R>(
+pub async fn create_relationships<R>(
     ports: &Ports<R>,
-    command: CreateRelationshipCommand,
-) -> CreateRelationshipResult<R::Error>
+    command: CreateRelationshipsCommand,
+) -> CreateRelationshipsResult<R::Error>
 where
     R: MemoryRepository + Send + Sync,
     R::Error: std::error::Error + Send + Sync + 'static,
@@ -50,7 +50,7 @@ mod tests {
         let service = MemoryService::new(mock, MemoryConfig::default());
         let ports = Ports::new(Arc::new(service));
 
-        let command = CreateRelationshipCommand {
+        let command = CreateRelationshipsCommand {
             relationships: vec![MemoryRelationship {
                 from: "a".to_string(),
                 to: "b".to_string(),
@@ -59,7 +59,7 @@ mod tests {
             }],
         };
 
-        let result = create_relationship(&ports, command).await;
+        let result = create_relationships(&ports, command).await;
         assert!(result.is_ok());
     }
 
@@ -70,7 +70,7 @@ mod tests {
         let service = MemoryService::new(mock, MemoryConfig::default());
         let ports = Ports::new(Arc::new(service));
 
-        let command = CreateRelationshipCommand {
+        let command = CreateRelationshipsCommand {
             relationships: vec![MemoryRelationship {
                 from: "a".to_string(),
                 to: "b".to_string(),
@@ -79,7 +79,7 @@ mod tests {
             }],
         };
 
-        let result = create_relationship(&ports, command).await;
+        let result = create_relationships(&ports, command).await;
         assert!(matches!(
             result,
             Err(CoreError::BatchValidation(ref errs)) if errs.iter().any(|(n, e)| n.is_empty() && e.0.contains(&ValidationErrorKind::UnknownRelationship("".to_string())))
@@ -93,7 +93,7 @@ mod tests {
         let service = MemoryService::new(mock, MemoryConfig::default());
         let ports = Ports::new(Arc::new(service));
 
-        let command = CreateRelationshipCommand {
+        let command = CreateRelationshipsCommand {
             relationships: vec![MemoryRelationship {
                 from: "a".to_string(),
                 to: "b".to_string(),
@@ -102,7 +102,7 @@ mod tests {
             }],
         };
 
-        let result = create_relationship(&ports, command).await;
+        let result = create_relationships(&ports, command).await;
         assert!(matches!(
             result,
             Err(CoreError::BatchValidation(ref errs)) if errs.iter().any(|(n, e)| n == "InvalidFormat" && e.0.contains(&ValidationErrorKind::InvalidRelationshipFormat("InvalidFormat".to_string())))
@@ -116,7 +116,7 @@ mod tests {
         let service = MemoryService::new(mock, MemoryConfig::default());
         let ports = Ports::new(Arc::new(service));
 
-        let command = CreateRelationshipCommand {
+        let command = CreateRelationshipsCommand {
             relationships: vec![MemoryRelationship {
                 from: "a".to_string(),
                 to: "b".to_string(),
@@ -125,7 +125,7 @@ mod tests {
             }],
         };
 
-        let result = create_relationship(&ports, command).await;
+        let result = create_relationships(&ports, command).await;
         assert!(matches!(
             result,
             Err(CoreError::BatchValidation(ref errs)) if errs.iter().any(|(n, e)| n == "custom_rel" && e.0.contains(&ValidationErrorKind::UnknownRelationship("custom_rel".to_string())))
@@ -140,7 +140,7 @@ mod tests {
         let service = MemoryService::new(mock, MemoryConfig::default());
         let ports = Ports::new(Arc::new(service));
 
-        let command = CreateRelationshipCommand {
+        let command = CreateRelationshipsCommand {
             relationships: vec![
                 MemoryRelationship {
                     from: "a".to_string(),
@@ -157,7 +157,7 @@ mod tests {
             ],
         };
 
-        let result = create_relationship(&ports, command).await;
+        let result = create_relationships(&ports, command).await;
 
         if let Err(CoreError::BatchValidation(errs)) = result {
             assert_eq!(errs.len(), 2);

--- a/crates/mm-core/src/operations/delete_entities.rs
+++ b/crates/mm-core/src/operations/delete_entities.rs
@@ -1,0 +1,33 @@
+use crate::error::{CoreError, CoreResult};
+use crate::ports::Ports;
+use mm_memory::MemoryRepository;
+use tracing::instrument;
+
+#[derive(Debug, Clone)]
+pub struct DeleteEntitiesCommand {
+    pub names: Vec<String>,
+}
+
+pub type DeleteEntitiesResult<E> = CoreResult<(), E>;
+
+#[instrument(skip(ports), fields(names_count = command.names.len()))]
+pub async fn delete_entities<R>(
+    ports: &Ports<R>,
+    command: DeleteEntitiesCommand,
+) -> DeleteEntitiesResult<R::Error>
+where
+    R: MemoryRepository + Send + Sync,
+    R::Error: std::error::Error + Send + Sync + 'static,
+{
+    let errors = ports
+        .memory_service
+        .delete_entities(&command.names)
+        .await
+        .map_err(CoreError::from)?;
+
+    if !errors.is_empty() {
+        return Err(CoreError::BatchValidation(errors));
+    }
+
+    Ok(())
+}

--- a/crates/mm-core/src/operations/delete_relationships.rs
+++ b/crates/mm-core/src/operations/delete_relationships.rs
@@ -1,0 +1,33 @@
+use crate::error::{CoreError, CoreResult};
+use crate::ports::Ports;
+use mm_memory::{MemoryRepository, relationship::RelationshipRef};
+use tracing::instrument;
+
+#[derive(Debug, Clone)]
+pub struct DeleteRelationshipsCommand {
+    pub relationships: Vec<RelationshipRef>,
+}
+
+pub type DeleteRelationshipsResult<E> = CoreResult<(), E>;
+
+#[instrument(skip(ports), fields(rel_count = command.relationships.len()))]
+pub async fn delete_relationships<R>(
+    ports: &Ports<R>,
+    command: DeleteRelationshipsCommand,
+) -> DeleteRelationshipsResult<R::Error>
+where
+    R: MemoryRepository + Send + Sync,
+    R::Error: std::error::Error + Send + Sync + 'static,
+{
+    let errors = ports
+        .memory_service
+        .delete_relationships(&command.relationships)
+        .await
+        .map_err(CoreError::from)?;
+
+    if !errors.is_empty() {
+        return Err(CoreError::BatchValidation(errors));
+    }
+
+    Ok(())
+}

--- a/crates/mm-core/src/operations/find_entities_by_labels.rs
+++ b/crates/mm-core/src/operations/find_entities_by_labels.rs
@@ -1,0 +1,41 @@
+use crate::error::{CoreError, CoreResult};
+use crate::ports::Ports;
+use mm_memory::{LabelMatchMode, MemoryEntity, MemoryRepository};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tracing::instrument;
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct FindEntitiesByLabelsCommand {
+    pub labels: Vec<String>,
+    pub match_mode: LabelMatchMode,
+    pub required_label: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct FindEntitiesByLabelsResult {
+    pub entities: Vec<MemoryEntity>,
+}
+
+pub type FindEntitiesByLabelsResultType<E> = CoreResult<FindEntitiesByLabelsResult, E>;
+
+#[instrument(skip(ports), fields(label_count = command.labels.len()))]
+pub async fn find_entities_by_labels<R>(
+    ports: &Ports<R>,
+    command: FindEntitiesByLabelsCommand,
+) -> FindEntitiesByLabelsResultType<R::Error>
+where
+    R: MemoryRepository + Send + Sync,
+    R::Error: std::error::Error + Send + Sync + 'static,
+{
+    let entities = ports
+        .memory_service
+        .find_entities_by_labels(
+            &command.labels,
+            command.match_mode,
+            command.required_label.clone(),
+        )
+        .await
+        .map_err(CoreError::from)?;
+    Ok(FindEntitiesByLabelsResult { entities })
+}

--- a/crates/mm-core/src/operations/find_relationships.rs
+++ b/crates/mm-core/src/operations/find_relationships.rs
@@ -1,0 +1,43 @@
+use crate::error::{CoreError, CoreResult};
+use crate::ports::Ports;
+use mm_memory::{MemoryRelationship, MemoryRepository};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tracing::instrument;
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct FindRelationshipsCommand {
+    pub from: Option<String>,
+    pub to: Option<String>,
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct FindRelationshipsResult {
+    pub relationships: Vec<MemoryRelationship>,
+}
+
+pub type FindRelationshipsResultType<E> = CoreResult<FindRelationshipsResult, E>;
+
+#[instrument(skip(ports))]
+pub async fn find_relationships<R>(
+    ports: &Ports<R>,
+    command: FindRelationshipsCommand,
+) -> FindRelationshipsResultType<R::Error>
+where
+    R: MemoryRepository + Send + Sync,
+    R::Error: std::error::Error + Send + Sync + 'static,
+{
+    let rels = ports
+        .memory_service
+        .find_relationships(
+            command.from.clone(),
+            command.to.clone(),
+            command.name.clone(),
+        )
+        .await
+        .map_err(CoreError::from)?;
+    Ok(FindRelationshipsResult {
+        relationships: rels,
+    })
+}

--- a/crates/mm-core/src/operations/mod.rs
+++ b/crates/mm-core/src/operations/mod.rs
@@ -1,8 +1,12 @@
 mod common;
 
 pub mod add_observations;
-pub mod create_entity;
-pub mod create_relationship;
+pub mod create_entity; // renamed file but keep mod
+pub mod create_relationship; // rename later
+pub mod delete_entities;
+pub mod delete_relationships;
+pub mod find_entities_by_labels;
+pub mod find_relationships;
 pub mod get_entity;
 pub mod get_project_context;
 pub mod list_projects;
@@ -13,9 +17,21 @@ pub mod update_entity;
 pub mod update_relationship;
 
 pub use add_observations::{AddObservationsCommand, AddObservationsResult, add_observations};
-pub use create_entity::{CreateEntityCommand, CreateEntityResult, create_entity};
+pub use create_entity::{CreateEntitiesCommand, CreateEntitiesResult, create_entities};
 pub use create_relationship::{
-    CreateRelationshipCommand, CreateRelationshipResult, create_relationship,
+    CreateRelationshipsCommand, CreateRelationshipsResult, create_relationships,
+};
+pub use delete_entities::{DeleteEntitiesCommand, DeleteEntitiesResult, delete_entities};
+pub use delete_relationships::{
+    DeleteRelationshipsCommand, DeleteRelationshipsResult, delete_relationships,
+};
+pub use find_entities_by_labels::{
+    FindEntitiesByLabelsCommand, FindEntitiesByLabelsResult, FindEntitiesByLabelsResultType,
+    find_entities_by_labels,
+};
+pub use find_relationships::{
+    FindRelationshipsCommand, FindRelationshipsResult, FindRelationshipsResultType,
+    find_relationships,
 };
 pub use get_entity::{GetEntityCommand, GetEntityResult, get_entity};
 pub use get_project_context::{

--- a/crates/mm-memory/src/relationship.rs
+++ b/crates/mm-memory/src/relationship.rs
@@ -17,3 +17,14 @@ pub struct MemoryRelationship {
     #[serde(default)]
     pub properties: HashMap<String, MemoryValue>,
 }
+
+/// Reference to a relationship without properties, used for deletion
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Hash, JsonSchema)]
+pub struct RelationshipRef {
+    /// Name of the source entity
+    pub from: String,
+    /// Name of the target entity
+    pub to: String,
+    /// Relationship type in snake_case
+    pub name: String,
+}

--- a/crates/mm-memory/src/repository.rs
+++ b/crates/mm-memory/src/repository.rs
@@ -44,6 +44,20 @@ pub trait MemoryRepository {
         relationships: &[MemoryRelationship],
     ) -> MemoryResult<(), Self::Error>;
 
+    async fn delete_entities(&self, names: &[String]) -> MemoryResult<(), Self::Error>;
+
+    async fn delete_relationships(
+        &self,
+        relationships: &[crate::relationship::RelationshipRef],
+    ) -> MemoryResult<(), Self::Error>;
+
+    async fn find_relationships(
+        &self,
+        from: Option<&str>,
+        to: Option<&str>,
+        name: Option<&str>,
+    ) -> MemoryResult<Vec<MemoryRelationship>, Self::Error>;
+
     async fn find_entities_by_labels(
         &self,
         labels: &[String],

--- a/crates/mm-server/src/lib.rs
+++ b/crates/mm-server/src/lib.rs
@@ -166,10 +166,14 @@ where
 
         // Match the tool variant and execute its corresponding logic
         let result = match tool_params {
-            MemoryTools::CreateEntityTool(create_entity_tool) => {
+            MemoryTools::CreateEntitiesTool(create_entity_tool) => {
                 create_entity_tool.call_tool(&self.ports).await?
             }
-            MemoryTools::CreateRelationshipTool(tool) => tool.call_tool(&self.ports).await?,
+            MemoryTools::CreateRelationshipsTool(tool) => tool.call_tool(&self.ports).await?,
+            MemoryTools::DeleteEntitiesTool(tool) => tool.call_tool(&self.ports).await?,
+            MemoryTools::DeleteRelationshipsTool(tool) => tool.call_tool(&self.ports).await?,
+            MemoryTools::FindEntitiesByLabelsTool(tool) => tool.call_tool(&self.ports).await?,
+            MemoryTools::FindRelationshipsTool(tool) => tool.call_tool(&self.ports).await?,
             MemoryTools::GetEntityTool(get_entity_tool) => {
                 get_entity_tool.call_tool(&self.ports).await?
             }
@@ -351,8 +355,12 @@ pub async fn run_tools<P: AsRef<Path>>(command: ToolsCommand, config_paths: &[P]
                 let tool =
                     MemoryTools::try_from(params).map_err(|e| anyhow::anyhow!(format!("{e:?}")))?;
                 let result = match tool {
-                    MemoryTools::CreateEntityTool(t) => t.call_tool(&ports).await,
-                    MemoryTools::CreateRelationshipTool(t) => t.call_tool(&ports).await,
+                    MemoryTools::CreateEntitiesTool(t) => t.call_tool(&ports).await,
+                    MemoryTools::CreateRelationshipsTool(t) => t.call_tool(&ports).await,
+                    MemoryTools::DeleteEntitiesTool(t) => t.call_tool(&ports).await,
+                    MemoryTools::DeleteRelationshipsTool(t) => t.call_tool(&ports).await,
+                    MemoryTools::FindEntitiesByLabelsTool(t) => t.call_tool(&ports).await,
+                    MemoryTools::FindRelationshipsTool(t) => t.call_tool(&ports).await,
                     MemoryTools::GetEntityTool(t) => t.call_tool(&ports).await,
                     MemoryTools::SetObservationsTool(t) => t.call_tool(&ports).await,
                     MemoryTools::AddObservationsTool(t) => t.call_tool(&ports).await,
@@ -372,8 +380,12 @@ pub async fn run_tools<P: AsRef<Path>>(command: ToolsCommand, config_paths: &[P]
                 anyhow::bail!("Unknown toolbox: {}", toolbox);
             }
             let schema = match tool_name.as_str() {
-                "create_entity" => mcp::CreateEntityTool::json_schema(),
-                "create_relationship" => mcp::CreateRelationshipTool::json_schema(),
+                "create_entities" => mcp::CreateEntitiesTool::json_schema(),
+                "create_relationships" => mcp::CreateRelationshipsTool::json_schema(),
+                "delete_entities" => mcp::DeleteEntitiesTool::json_schema(),
+                "delete_relationships" => mcp::DeleteRelationshipsTool::json_schema(),
+                "find_entities_by_labels" => mcp::FindEntitiesByLabelsTool::json_schema(),
+                "find_relationships" => mcp::FindRelationshipsTool::json_schema(),
                 "get_entity" => mcp::GetEntityTool::json_schema(),
                 "set_observations" => mcp::SetObservationsTool::json_schema(),
                 "add_observations" => mcp::AddObservationsTool::json_schema(),

--- a/crates/mm-server/src/mcp/create_entities.rs
+++ b/crates/mm-server/src/mcp/create_entities.rs
@@ -1,25 +1,25 @@
-use mm_core::{CreateEntityCommand, MemoryEntity, create_entity};
+use mm_core::{CreateEntitiesCommand, MemoryEntity, create_entities};
 use mm_utils::IntoJsonSchema;
 use rust_mcp_sdk::macros::mcp_tool;
 use serde::{Deserialize, Serialize};
 
 #[mcp_tool(
-    name = "create_entity",
-    description = "Create a new entity in the memory graph"
+    name = "create_entities",
+    description = "Create new entities in the memory graph"
 )]
 #[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
-pub struct CreateEntityTool {
+pub struct CreateEntitiesTool {
     /// Entities to create
     pub entities: Vec<MemoryEntity>,
 }
 
-impl CreateEntityTool {
+impl CreateEntitiesTool {
     generate_call_tool!(
         self,
-        CreateEntityCommand {
+        CreateEntitiesCommand {
             entities => self.entities.clone()
         },
-        create_entity,
+        create_entities,
         |command, _result| {
             serde_json::to_value(command.entities)
                 .map(|json| rust_mcp_sdk::schema::CallToolResult::text_content(json.to_string(), None))
@@ -55,7 +55,7 @@ mod tests {
         );
         let ports = Ports::new(Arc::new(service));
 
-        let tool = CreateEntityTool {
+        let tool = CreateEntitiesTool {
             entities: vec![MemoryEntity {
                 name: "test:entity".to_string(),
                 labels: vec!["Test".to_string()],
@@ -86,7 +86,7 @@ mod tests {
         let service = MemoryService::new(mock, MemoryConfig::default());
         let ports = Ports::new(Arc::new(service));
 
-        let tool = CreateEntityTool {
+        let tool = CreateEntitiesTool {
             entities: vec![MemoryEntity {
                 name: "test:entity".to_string(),
                 labels: vec!["Test".to_string()],
@@ -106,7 +106,7 @@ mod schema_tests {
     #[test]
     fn test_schema_has_no_refs() {
         // Generate the schema for CreateEntityTool
-        let schema = CreateEntityTool::json_schema();
+        let schema = CreateEntitiesTool::json_schema();
 
         // Convert to a Value for easier inspection
         let schema_value =

--- a/crates/mm-server/src/mcp/create_relationships.rs
+++ b/crates/mm-server/src/mcp/create_relationships.rs
@@ -1,4 +1,4 @@
-use mm_core::{CreateRelationshipCommand, MemoryRelationship, create_relationship};
+use mm_core::{CreateRelationshipsCommand, MemoryRelationship, create_relationships};
 use mm_memory::MemoryValue;
 use mm_utils::IntoJsonSchema;
 use rust_mcp_sdk::macros::mcp_tool;
@@ -26,25 +26,25 @@ impl RelationshipInput {
 }
 
 #[mcp_tool(
-    name = "create_relationship",
-    description = "Create a relationship between two entities"
+    name = "create_relationships",
+    description = "Create relationships between entities"
 )]
 #[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
-pub struct CreateRelationshipTool {
+pub struct CreateRelationshipsTool {
     pub relationships: Vec<RelationshipInput>,
 }
 
-impl CreateRelationshipTool {
+impl CreateRelationshipsTool {
     generate_call_tool!(
         self,
-        CreateRelationshipCommand {
+        CreateRelationshipsCommand {
             relationships => self
                 .relationships
                 .iter()
                 .map(RelationshipInput::to_memory_relationship)
                 .collect(),
         },
-        create_relationship,
+        create_relationships,
         |_cmd, _res| {
             Ok(rust_mcp_sdk::schema::CallToolResult::text_content(
                 "Relationships created".to_string(),
@@ -71,7 +71,7 @@ mod tests {
         let service = MemoryService::new(mock, MemoryConfig::default());
         let ports = Ports::new(Arc::new(service));
 
-        let tool = CreateRelationshipTool {
+        let tool = CreateRelationshipsTool {
             relationships: vec![RelationshipInput {
                 from: "a".to_string(),
                 to: "b".to_string(),
@@ -94,7 +94,7 @@ mod tests {
         let service = MemoryService::new(mock, MemoryConfig::default());
         let ports = Ports::new(Arc::new(service));
 
-        let tool = CreateRelationshipTool {
+        let tool = CreateRelationshipsTool {
             relationships: vec![RelationshipInput {
                 from: "a".to_string(),
                 to: "b".to_string(),
@@ -115,7 +115,7 @@ mod schema_tests {
     #[test]
     fn test_schema_has_no_refs() {
         // Generate the schema for CreateRelationshipTool
-        let schema = CreateRelationshipTool::json_schema();
+        let schema = CreateRelationshipsTool::json_schema();
 
         // Convert to a string to check for $defs
         let schema_str =

--- a/crates/mm-server/src/mcp/delete_entities.rs
+++ b/crates/mm-server/src/mcp/delete_entities.rs
@@ -1,0 +1,27 @@
+use mm_core::{DeleteEntitiesCommand, delete_entities};
+use mm_utils::IntoJsonSchema;
+use rust_mcp_sdk::macros::mcp_tool;
+use serde::{Deserialize, Serialize};
+
+#[mcp_tool(
+    name = "delete_entities",
+    description = "Delete entities from the memory graph"
+)]
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct DeleteEntitiesTool {
+    pub names: Vec<String>,
+}
+
+impl DeleteEntitiesTool {
+    generate_call_tool!(
+        self,
+        DeleteEntitiesCommand { names => self.names.clone() },
+        delete_entities,
+        |_cmd, _res| {
+            Ok(rust_mcp_sdk::schema::CallToolResult::text_content(
+                "Entities deleted".to_string(),
+                None,
+            ))
+        }
+    );
+}

--- a/crates/mm-server/src/mcp/delete_relationships.rs
+++ b/crates/mm-server/src/mcp/delete_relationships.rs
@@ -1,0 +1,28 @@
+use mm_core::{DeleteRelationshipsCommand, delete_relationships};
+use mm_memory::RelationshipRef;
+use mm_utils::IntoJsonSchema;
+use rust_mcp_sdk::macros::mcp_tool;
+use serde::{Deserialize, Serialize};
+
+#[mcp_tool(
+    name = "delete_relationships",
+    description = "Delete relationships from the memory graph"
+)]
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct DeleteRelationshipsTool {
+    pub relationships: Vec<RelationshipRef>,
+}
+
+impl DeleteRelationshipsTool {
+    generate_call_tool!(
+        self,
+        DeleteRelationshipsCommand { relationships => self.relationships.clone() },
+        delete_relationships,
+        |_cmd, _res| {
+            Ok(rust_mcp_sdk::schema::CallToolResult::text_content(
+                "Relationships deleted".to_string(),
+                None,
+            ))
+        }
+    );
+}

--- a/crates/mm-server/src/mcp/find_entities_by_labels.rs
+++ b/crates/mm-server/src/mcp/find_entities_by_labels.rs
@@ -1,0 +1,33 @@
+use mm_core::{FindEntitiesByLabelsCommand, FindEntitiesByLabelsResult, find_entities_by_labels};
+use mm_memory::LabelMatchMode;
+use mm_utils::IntoJsonSchema;
+use rust_mcp_sdk::macros::mcp_tool;
+use serde::{Deserialize, Serialize};
+
+#[mcp_tool(
+    name = "find_entities_by_labels",
+    description = "Find entities matching labels"
+)]
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct FindEntitiesByLabelsTool {
+    pub labels: Vec<String>,
+    pub match_mode: LabelMatchMode,
+    pub required_label: Option<String>,
+}
+
+impl FindEntitiesByLabelsTool {
+    generate_call_tool!(
+        self,
+        FindEntitiesByLabelsCommand {
+            labels => self.labels.clone(),
+            match_mode => self.match_mode,
+            required_label => self.required_label.clone()
+        },
+        find_entities_by_labels,
+        |_cmd, res: FindEntitiesByLabelsResult| {
+            serde_json::to_value(res.entities)
+                .map(|j| rust_mcp_sdk::schema::CallToolResult::text_content(j.to_string(), None))
+                .map_err(|e| rust_mcp_sdk::schema::schema_utils::CallToolError::new(crate::mcp::error::ToolError::from(e)))
+        }
+    );
+}

--- a/crates/mm-server/src/mcp/find_relationships.rs
+++ b/crates/mm-server/src/mcp/find_relationships.rs
@@ -1,0 +1,32 @@
+use mm_core::{FindRelationshipsCommand, FindRelationshipsResult, find_relationships};
+use mm_utils::IntoJsonSchema;
+use rust_mcp_sdk::macros::mcp_tool;
+use serde::{Deserialize, Serialize};
+
+#[mcp_tool(
+    name = "find_relationships",
+    description = "Find relationships between entities"
+)]
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct FindRelationshipsTool {
+    pub from: Option<String>,
+    pub to: Option<String>,
+    pub name: Option<String>,
+}
+
+impl FindRelationshipsTool {
+    generate_call_tool!(
+        self,
+        FindRelationshipsCommand {
+            from => self.from.clone(),
+            to => self.to.clone(),
+            name => self.name.clone()
+        },
+        find_relationships,
+        |_cmd, res: FindRelationshipsResult| {
+            serde_json::to_value(res.relationships)
+                .map(|j| rust_mcp_sdk::schema::CallToolResult::text_content(j.to_string(), None))
+                .map_err(|e| rust_mcp_sdk::schema::schema_utils::CallToolError::new(crate::mcp::error::ToolError::from(e)))
+        }
+    );
+}

--- a/crates/mm-server/src/mcp/mod.rs
+++ b/crates/mm-server/src/mcp/mod.rs
@@ -1,9 +1,13 @@
 #[macro_use]
 mod macros;
-pub mod add_observations;
-pub mod create_entity;
-pub mod create_relationship;
+pub mod add_observations; // deprecated
+pub mod create_entities;
+pub mod create_relationships;
+pub mod delete_entities;
+pub mod delete_relationships;
 pub mod error;
+pub mod find_entities_by_labels;
+pub mod find_relationships;
 pub mod get_entity;
 pub mod get_project_context;
 pub mod list_projects;
@@ -16,14 +20,18 @@ pub mod update_relationship;
 use rust_mcp_sdk::tool_box;
 
 pub use add_observations::AddObservationsTool;
-pub use create_entity::CreateEntityTool;
-pub use create_relationship::CreateRelationshipTool;
+pub use create_entities::CreateEntitiesTool;
+pub use create_relationships::CreateRelationshipsTool;
+pub use delete_entities::DeleteEntitiesTool;
+pub use delete_relationships::DeleteRelationshipsTool;
+pub use find_entities_by_labels::FindEntitiesByLabelsTool;
+pub use find_relationships::FindRelationshipsTool;
 pub use get_entity::GetEntityTool;
 pub use get_project_context::GetProjectContextTool;
 pub use list_projects::ListProjectsTool;
-pub use remove_all_observations::RemoveAllObservationsTool;
-pub use remove_observations::RemoveObservationsTool;
-pub use set_observations::SetObservationsTool;
+pub use remove_all_observations::RemoveAllObservationsTool; // deprecated
+pub use remove_observations::RemoveObservationsTool; // deprecated
+pub use set_observations::SetObservationsTool; // deprecated
 pub use update_entity::UpdateEntityTool;
 pub use update_relationship::UpdateRelationshipTool;
 
@@ -31,9 +39,14 @@ pub use update_relationship::UpdateRelationshipTool;
 tool_box!(
     MemoryTools,
     [
-        CreateEntityTool,
-        CreateRelationshipTool,
+        CreateEntitiesTool,
+        CreateRelationshipsTool,
+        DeleteEntitiesTool,
+        DeleteRelationshipsTool,
+        FindEntitiesByLabelsTool,
+        FindRelationshipsTool,
         GetEntityTool,
+        // Deprecated observation tools below
         SetObservationsTool,
         AddObservationsTool,
         RemoveAllObservationsTool,


### PR DESCRIPTION
## Summary
- add `RelationshipRef` and batch delete operations
- implement new memory service methods for deleting and querying
- expose new MCP tools for batch operations and queries

## Testing
- `just fmt`
- `just validate` *(fails: could not compile)*

------
https://chatgpt.com/codex/tasks/task_e_685a1180d95083278b4f68e58ae6be62