### PR TITLE
feat(memory): Add agent_name to MemoryConfig

### DIFF
--- a/crates/mm-core/src/operations/create_entity.rs
+++ b/crates/mm-core/src/operations/create_entity.rs
@@ -65,6 +65,7 @@ mod tests {
             MemoryConfig {
                 default_label: None,
                 default_labels: false,
+                agent_name: "test".to_string(),
                 ..MemoryConfig::default()
             },
         );
@@ -92,6 +93,7 @@ mod tests {
             MemoryConfig {
                 default_label: None,
                 default_labels: false,
+                agent_name: "test".to_string(),
                 ..MemoryConfig::default()
             },
         );
@@ -127,6 +129,7 @@ mod tests {
             MemoryConfig {
                 default_label: None,
                 default_labels: false,
+                agent_name: "test".to_string(),
                 ..MemoryConfig::default()
             },
         );
@@ -155,6 +158,7 @@ mod tests {
             MemoryConfig {
                 default_label: None,
                 default_labels: false,
+                agent_name: "test".to_string(),
                 ..MemoryConfig::default()
             },
         );

--- a/crates/mm-memory-neo4j/tests/neo4j_integration.rs
+++ b/crates/mm-memory-neo4j/tests/neo4j_integration.rs
@@ -36,6 +36,7 @@ async fn test_find_nonexistent_entity() {
             default_labels: true,
             additional_labels: std::iter::once("Example".to_string()).collect(),
             default_project: None,
+            agent_name: "test".to_string(),
         },
     )
     .await
@@ -66,6 +67,7 @@ async fn test_create_and_find_entity() {
             default_labels: true,
             additional_labels: std::iter::once("Example".to_string()).collect(),
             default_project: None,
+            agent_name: "test".to_string(),
         },
     )
     .await
@@ -124,6 +126,7 @@ async fn test_validation_errors() {
             default_labels: true,
             additional_labels: std::iter::once("Example".to_string()).collect(),
             default_project: None,
+            agent_name: "test".to_string(),
         },
     )
     .await
@@ -169,6 +172,7 @@ async fn test_set_observations() {
             default_labels: true,
             additional_labels: std::iter::once("Example".to_string()).collect(),
             default_project: None,
+            agent_name: "test".to_string(),
         },
     )
     .await
@@ -217,6 +221,7 @@ async fn test_add_and_remove_observations() {
             default_labels: true,
             additional_labels: std::iter::once("Example".to_string()).collect(),
             default_project: None,
+            agent_name: "test".to_string(),
         },
     )
     .await
@@ -286,6 +291,7 @@ async fn test_create_relationship() {
             default_labels: true,
             additional_labels: std::iter::once("Example".to_string()).collect(),
             default_project: None,
+            agent_name: "test".to_string(),
         },
     )
     .await
@@ -357,6 +363,7 @@ async fn test_find_related_entities() {
             default_labels: true,
             additional_labels: std::iter::once("Example".to_string()).collect(),
             default_project: None,
+            agent_name: "test".to_string(),
         },
     )
     .await
@@ -432,6 +439,7 @@ async fn test_find_entities_by_labels() {
                 .into_iter()
                 .collect(),
             default_project: None,
+            agent_name: "test".to_string(),
         },
     )
     .await

--- a/crates/mm-memory/src/config.rs
+++ b/crates/mm-memory/src/config.rs
@@ -27,6 +27,10 @@ pub struct MemoryConfig {
     /// Optional default project name to use when not explicitly specified
     #[serde(default)]
     pub default_project: Option<String>,
+
+    /// Name of the agent using this configuration
+    #[serde(default)]
+    pub agent_name: String,
 }
 
 /// Default label used when none is specified in the configuration
@@ -130,6 +134,7 @@ impl Default for MemoryConfig {
             default_labels: true,
             additional_labels: HashSet::default(),
             default_project: None,
+            agent_name: "unknown".to_string(),
         }
     }
 }

--- a/crates/mm-memory/src/service.rs
+++ b/crates/mm-memory/src/service.rs
@@ -531,6 +531,7 @@ mod tests {
                 default_labels: false,
                 additional_labels: HashSet::default(),
                 default_project: None,
+                agent_name: "test".to_string(),
             },
         );
         let entity = MemoryEntity {
@@ -562,6 +563,7 @@ mod tests {
                 default_labels: false,
                 additional_labels: HashSet::default(),
                 default_project: None,
+                agent_name: "test".to_string(),
             },
         );
         let entity = MemoryEntity {
@@ -597,6 +599,7 @@ mod tests {
                 default_labels: false,
                 additional_labels: HashSet::default(),
                 default_project: None,
+                agent_name: "test".to_string(),
             },
         );
 
@@ -627,6 +630,7 @@ mod tests {
                 default_labels: false,
                 additional_labels: HashSet::default(),
                 default_project: None,
+                agent_name: "test".to_string(),
             },
         );
 
@@ -663,6 +667,7 @@ mod tests {
                 default_labels: true,
                 additional_labels: HashSet::default(),
                 default_project: None,
+                agent_name: "test".to_string(),
             },
         );
 
@@ -693,6 +698,7 @@ mod tests {
                 default_labels: true,
                 additional_labels: HashSet::default(),
                 default_project: None,
+                agent_name: "test".to_string(),
             },
         );
 
@@ -726,6 +732,7 @@ mod tests {
                 default_labels: true,
                 additional_labels: HashSet::default(),
                 default_project: None,
+                agent_name: "test".to_string(),
             },
         );
 
@@ -756,6 +763,7 @@ mod tests {
                 default_labels: true,
                 additional_labels: HashSet::default(),
                 default_project: None,
+                agent_name: "test".to_string(),
             },
         );
 
@@ -793,6 +801,7 @@ mod tests {
                 default_labels: false,
                 additional_labels: HashSet::default(),
                 default_project: None,
+                agent_name: "test".to_string(),
             },
         );
 
@@ -821,6 +830,7 @@ mod tests {
                 default_labels: true,
                 additional_labels: HashSet::default(),
                 default_project: None,
+                agent_name: "test".to_string(),
             },
         );
 
@@ -931,6 +941,7 @@ mod tests {
                 default_labels: true,
                 additional_labels: HashSet::default(),
                 default_project: None,
+                agent_name: "test".to_string(),
             },
         );
 
@@ -960,6 +971,7 @@ mod tests {
                 default_labels: true,
                 additional_labels: HashSet::default(),
                 default_project: None,
+                agent_name: "test".to_string(),
             },
         );
 

--- a/crates/mm-memory/src/test_suite.rs
+++ b/crates/mm-memory/src/test_suite.rs
@@ -24,6 +24,7 @@ where
         default_labels: true,
         additional_labels: std::iter::once("Example".to_string()).collect(),
         default_project: None,
+        agent_name: "test".to_string(),
     };
 
     let service = MemoryService::new(repository, config);

--- a/crates/mm-server/src/config.rs
+++ b/crates/mm-server/src/config.rs
@@ -71,6 +71,7 @@ mod tests {
         let config_content = r#"
 [memory]
 default_label = "TestTag"
+agent_name = "tester"
 [neo4j]
 uri = "neo4j://testhost:7687"
 username = "test_user"
@@ -86,6 +87,7 @@ password = "test_password"
         assert_eq!(config.neo4j.username, "test_user");
         assert_eq!(config.neo4j.password, "test_password");
         assert_eq!(config.memory.default_label, Some("TestTag".to_string()));
+        assert_eq!(config.memory.agent_name, "tester".to_string());
         assert!(config.memory.default_relationships);
     }
 
@@ -104,6 +106,7 @@ password = "test_password"
                 default_labels: true,
                 additional_labels: std::collections::HashSet::default(),
                 default_project: None,
+                agent_name: "test".to_string(),
             },
         };
 

--- a/crates/mm-server/src/mcp/create_entities.rs
+++ b/crates/mm-server/src/mcp/create_entities.rs
@@ -50,6 +50,7 @@ mod tests {
             mock,
             MemoryConfig {
                 default_labels: false,
+                agent_name: "test".to_string(),
                 ..MemoryConfig::default()
             },
         );


### PR DESCRIPTION
## Summary
- add `agent_name` field to `MemoryConfig`
- set default agent_name to `"unknown"`
- update server config tests and memory service tests with the new field
- include agent_name in various config builders

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_685a3235f1cc83279e464043904aff55