### PR TITLE
Add Task and Project types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1419,6 +1419,7 @@ dependencies = [
  "arbitrary",
  "arbtest",
  "async-trait",
+ "chrono",
  "mm-memory",
  "mm-utils",
  "mockall",

--- a/crates/mm-core/Cargo.toml
+++ b/crates/mm-core/Cargo.toml
@@ -12,6 +12,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 async-trait = { workspace = true }
 schemars = { workspace = true }
+chrono = { workspace = true }
 
 [dev-dependencies]
 mockall = { workspace = true }

--- a/crates/mm-core/src/lib.rs
+++ b/crates/mm-core/src/lib.rs
@@ -30,3 +30,4 @@ pub use root::{Root, RootCollection};
 
 // Re-export types from mm-memory
 pub use mm_memory::{MemoryEntity, MemoryRelationship, ProjectContext};
+pub use operations::{Priority, TaskProperties, TaskStatus, TaskType};

--- a/crates/mm-core/src/operations/git/mod.rs
+++ b/crates/mm-core/src/operations/git/mod.rs
@@ -1,0 +1,1 @@
+pub mod types;

--- a/crates/mm-core/src/operations/git/types.rs
+++ b/crates/mm-core/src/operations/git/types.rs
@@ -1,0 +1,12 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Properties for GitRepository entities
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Default)]
+pub struct GitRepositoryProperties {
+    /// Repository URL (e.g., "https://github.com/andoriyu/middle-manager")
+    pub url: String,
+
+    /// Default branch name
+    pub default_branch: String,
+}

--- a/crates/mm-core/src/operations/mod.rs
+++ b/crates/mm-core/src/operations/mod.rs
@@ -1,4 +1,6 @@
 mod common;
+mod git;
+mod tasks;
 
 pub mod create_entity; // renamed file but keep mod
 pub mod create_relationship; // rename later
@@ -33,6 +35,7 @@ pub use get_project_context::{
     GetProjectContextCommand, GetProjectContextResult, ProjectFilter, get_project_context,
 };
 pub use list_projects::{ListProjectsCommand, ListProjectsResult, list_projects};
+pub use tasks::{Priority, TaskProperties, TaskStatus, TaskType};
 pub use update_entity::{UpdateEntityCommand, UpdateEntityResult, update_entity};
 pub use update_relationship::{
     UpdateRelationshipCommand, UpdateRelationshipResult, update_relationship,

--- a/crates/mm-core/src/operations/projects/types.rs
+++ b/crates/mm-core/src/operations/projects/types.rs
@@ -1,0 +1,69 @@
+use chrono::{DateTime, Utc};
+use mm_memory::MemoryEntity;
+
+use crate::operations::{git::types::GitRepositoryProperties, tasks::TaskProperties};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Properties for Project entities
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Default)]
+pub struct ProjectProperties {
+    /// Description of the project
+    pub description: String,
+
+    /// Creation date
+    pub created_at: DateTime<Utc>,
+
+    /// Last updated date
+    pub updated_at: DateTime<Utc>,
+
+    /// Project status
+    pub status: ProjectStatus,
+
+    /// Project type
+    pub project_type: ProjectType,
+
+}
+
+/// Context information about a project
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct ProjectContext {
+    /// The project entity
+    pub project: MemoryEntity<ProjectProperties>,
+
+    /// Associated git repository (if any)
+    pub git_repository: Option<MemoryEntity<GitRepositoryProperties>>,
+
+    /// Tasks associated with the project
+    pub tasks: Vec<MemoryEntity<TaskProperties>>,
+
+    /// Technologies used in the project
+    pub technologies: Vec<MemoryEntity>,
+
+    /// Notes related to the project
+    pub notes: Vec<MemoryEntity>,
+
+    /// Other related entities
+    pub other_related_entities: Vec<MemoryEntity>,
+}
+
+/// Project status
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub enum ProjectStatus {
+    Active,
+    Maintenance,
+    Archived,
+    Planning,
+}
+
+/// Project type
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub enum ProjectType {
+    Application,
+    Library,
+    Tool,
+    Configuration,
+    Documentation,
+    Other,
+}

--- a/crates/mm-core/src/operations/tasks/mod.rs
+++ b/crates/mm-core/src/operations/tasks/mod.rs
@@ -1,0 +1,3 @@
+pub mod types;
+
+pub use types::{Priority, TaskProperties, TaskStatus, TaskType};

--- a/crates/mm-core/src/operations/tasks/types.rs
+++ b/crates/mm-core/src/operations/tasks/types.rs
@@ -1,0 +1,59 @@
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Priority level for a task
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub enum Priority {
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+/// Status of a task
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub enum TaskStatus {
+    Todo,
+    InProgress,
+    Blocked,
+    Done,
+    Cancelled,
+}
+
+/// Type of task
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+pub enum TaskType {
+    Feature,
+    Bug,
+    Chore,
+    Improvement,
+}
+
+/// Properties for Task entities
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub struct TaskProperties {
+    /// Short description of the task
+    pub description: String,
+
+    /// When the task was created
+    #[schemars(with = "String")]
+    pub created_at: DateTime<Utc>,
+
+    /// When the task was last updated
+    #[schemars(with = "String")]
+    pub updated_at: DateTime<Utc>,
+
+    /// When the task is due
+    #[schemars(with = "Option<String>")]
+    pub due_date: Option<DateTime<Utc>>,
+
+    /// Task type
+    pub task_type: TaskType,
+
+    /// Task status
+    pub status: TaskStatus,
+
+    /// Task priority
+    pub priority: Priority,
+}


### PR DESCRIPTION
## Summary
- define task-related enums and properties
- add Git repository properties
- define project properties and context referencing typed memory entities
- expose task enums via operations
- update mm-core crate dependencies

## Testing
- `just validate`


------
https://chatgpt.com/codex/tasks/task_e_685a327943a08327989db8af1cf8a43c