### PR TITLE
Add git status tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,7 +199,7 @@ async fn test_get_entity_success() {
             properties: HashMap::default(),
         })));
     
-    let ports = Ports::new(Arc::new(mock));
+    let ports = Ports::new(Arc::new(mock), Arc::new(mm_git::NoopGitService));
     
     let command = GetEntityCommand {
         name: "test:entity".to_string(),

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,6 +883,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "git2"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232e6a7bfe35766bf715e55a88b39a700596c0ccfd88cd3680b4cdb40d66ef70"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,6 +1303,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.16.2+1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,6 +1324,32 @@ checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
  "windows-targets 0.53.2",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1419,6 +1474,7 @@ dependencies = [
  "arbitrary",
  "arbtest",
  "async-trait",
+ "mm-git",
  "mm-memory",
  "mm-utils",
  "mockall",
@@ -1428,6 +1484,24 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "mm-git"
+version = "0.1.0"
+dependencies = [
+ "schemars",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "mm-git-libgit2"
+version = "0.1.0"
+dependencies = [
+ "git2",
+ "mm-git",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1473,6 +1547,8 @@ dependencies = [
  "clap",
  "config",
  "mm-core",
+ "mm-git",
+ "mm-git-libgit2",
  "mm-memory",
  "mm-memory-neo4j",
  "mm-utils",
@@ -1634,6 +1710,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-sys"
+version = "0.9.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1792,6 +1880,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "potential_utf"
@@ -2991,6 +3085,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ members = [
     "crates/mm-memory",
     "crates/mm-memory-neo4j",
     "crates/mm-server",
+    "crates/mm-git",
+    "crates/mm-git-libgit2",
     "crates/mm-utils",
 ]
 resolver = "3"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The `memory://` scheme is dynamic: any entity name can be requested. The server 
 | `add_observations` | Append observations to an entity |
 | `remove_observations` | Remove specific observations from an entity |
 | `remove_all_observations` | Delete all observations from an entity |
+| `git_status` | Retrieve repository status information |
 
 ## Project Structure
 
@@ -131,6 +132,10 @@ graph TD
 
 - Fetch any entity with `memory://{name}`; `list_resource_templates` advertises this
 - Configurable logging
+
+### Git
+
+- Retrieve Git repository status with `git_status`
 
 ## Building
 

--- a/crates/mm-core/Cargo.toml
+++ b/crates/mm-core/Cargo.toml
@@ -12,6 +12,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 async-trait = { workspace = true }
 schemars = { workspace = true }
+mm-git = { path = "../mm-git" }
 
 [dev-dependencies]
 mockall = { workspace = true }

--- a/crates/mm-core/src/error.rs
+++ b/crates/mm-core/src/error.rs
@@ -16,6 +16,12 @@ where
     #[error("Validation error")]
     Validation(#[from] mm_memory::ValidationError),
 
+    #[error("Git error")]
+    Git(#[from] mm_git::GitError),
+
+    #[error("Git service not configured")]
+    GitNotConfigured,
+
     /// Multiple validation errors grouped by name
     #[error("Batch validation error")]
     BatchValidation(Vec<(String, mm_memory::ValidationError)>),
@@ -23,3 +29,12 @@ where
 
 /// Result type for mm-core
 pub type CoreResult<T, E> = std::result::Result<T, CoreError<E>>;
+
+impl<E> CoreError<E>
+where
+    E: StdError + Send + Sync + 'static,
+{
+    pub fn git_not_configured() -> Self {
+        CoreError::GitNotConfigured
+    }
+}

--- a/crates/mm-core/src/lib.rs
+++ b/crates/mm-core/src/lib.rs
@@ -16,16 +16,20 @@ pub use mm_memory::MemoryService;
 pub use operations::{
     AddObservationsCommand, AddObservationsResult, CreateEntityCommand, CreateEntityResult,
     CreateRelationshipCommand, CreateRelationshipResult, GetEntityCommand, GetEntityResult,
-    GetProjectContextCommand, GetProjectContextResult, ListProjectsCommand, ListProjectsResult,
-    ProjectFilter, RemoveAllObservationsCommand, RemoveAllObservationsResult,
-    RemoveObservationsCommand, RemoveObservationsResult, SetObservationsCommand,
-    SetObservationsResult, UpdateEntityCommand, UpdateEntityResult, UpdateRelationshipCommand,
-    UpdateRelationshipResult, add_observations, create_entity, create_relationship, get_entity,
-    get_project_context, list_projects, remove_all_observations, remove_observations,
-    set_observations, update_entity, update_relationship,
+    GetGitStatusCommand, GetGitStatusResult, GetProjectContextCommand, GetProjectContextResult,
+    ListProjectsCommand, ListProjectsResult, ProjectFilter, RemoveAllObservationsCommand,
+    RemoveAllObservationsResult, RemoveObservationsCommand, RemoveObservationsResult,
+    SetObservationsCommand, SetObservationsResult, UpdateEntityCommand, UpdateEntityResult,
+    UpdateRelationshipCommand, UpdateRelationshipResult, add_observations, create_entity,
+    create_relationship, get_entity, get_git_status, get_project_context, list_projects,
+    remove_all_observations, remove_observations, set_observations, update_entity,
+    update_relationship,
 };
 pub use ports::Ports;
 pub use root::{Root, RootCollection};
+
+// Re-export types from mm-git
+pub use mm_git::RepositoryStatus;
 
 // Re-export types from mm-memory
 pub use mm_memory::{MemoryEntity, MemoryRelationship, ProjectContext};

--- a/crates/mm-core/src/operations/add_observations.rs
+++ b/crates/mm-core/src/operations/add_observations.rs
@@ -1,6 +1,7 @@
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
 use crate::validate_name;
+use mm_git::GitServiceTrait;
 use mm_memory::MemoryRepository;
 use tracing::instrument;
 
@@ -13,13 +14,14 @@ pub struct AddObservationsCommand {
 pub type AddObservationsResult<E> = CoreResult<(), E>;
 
 #[instrument(skip(ports), fields(name = %command.name, observations_count = command.observations.len()))]
-pub async fn add_observations<R>(
-    ports: &Ports<R>,
+pub async fn add_observations<R, G>(
+    ports: &Ports<R, G>,
     command: AddObservationsCommand,
 ) -> AddObservationsResult<R::Error>
 where
     R: MemoryRepository + Send + Sync,
     R::Error: std::error::Error + Send + Sync + 'static,
+    G: GitServiceTrait + Send + Sync,
 {
     validate_name!(command.name);
 
@@ -45,7 +47,7 @@ mod tests {
             .withf(|name, obs| name == "test:entity" && obs.len() == 1)
             .returning(|_, _| Ok(()));
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
         let command = AddObservationsCommand {
             name: "test:entity".to_string(),
             observations: vec!["obs".to_string()],
@@ -59,7 +61,7 @@ mod tests {
         let mut mock = MockMemoryRepository::new();
         mock.expect_add_observations().never();
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
         let command = AddObservationsCommand {
             name: "".to_string(),
             observations: vec![],
@@ -78,7 +80,7 @@ mod tests {
             .withf(|name, _| name == "test:entity")
             .returning(|_, _| Err(MemoryError::runtime_error("fail")));
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
         let command = AddObservationsCommand {
             name: "test:entity".to_string(),
             observations: vec!["obs".to_string()],
@@ -102,7 +104,7 @@ mod tests {
                 .withf(move |n, o| n == name_clone && o == obs_clone.as_slice())
                 .returning(|_, _| Ok(()));
             let service = MemoryService::new(mock, MemoryConfig::default());
-            let ports = Ports::new(Arc::new(service));
+            let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
             let command = AddObservationsCommand { name, observations };
             let result = rt.block_on(add_observations(&ports, command));
             assert!(result.is_ok());
@@ -117,7 +119,7 @@ mod tests {
             let mut mock = MockMemoryRepository::new();
             mock.expect_add_observations().never();
             let service = MemoryService::new(mock, MemoryConfig::default());
-            let ports = Ports::new(Arc::new(service));
+            let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
             let command = AddObservationsCommand {
                 name: String::default(),
                 observations,

--- a/crates/mm-core/src/operations/create_entity.rs
+++ b/crates/mm-core/src/operations/create_entity.rs
@@ -1,6 +1,7 @@
 use crate::MemoryEntity;
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
+use mm_git::GitServiceTrait;
 use mm_memory::MemoryRepository;
 use tracing::instrument;
 
@@ -24,13 +25,14 @@ pub type CreateEntityResult<E> = CoreResult<(), E>;
 ///
 /// Ok(()) if the entity was created successfully, or an error
 #[instrument(skip(ports), fields(entities_count = command.entities.len()))]
-pub async fn create_entity<R>(
-    ports: &Ports<R>,
+pub async fn create_entity<R, G>(
+    ports: &Ports<R, G>,
     command: CreateEntityCommand,
 ) -> CreateEntityResult<R::Error>
 where
     R: MemoryRepository + Send + Sync,
     R::Error: std::error::Error + Send + Sync + 'static,
+    G: GitServiceTrait + Send + Sync,
 {
     let errors = ports
         .memory_service
@@ -68,7 +70,7 @@ mod tests {
                 ..MemoryConfig::default()
             },
         );
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let command = CreateEntityCommand {
             entities: vec![MemoryEntity {
@@ -95,7 +97,7 @@ mod tests {
                 ..MemoryConfig::default()
             },
         );
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let command = CreateEntityCommand {
             entities: vec![MemoryEntity {
@@ -130,7 +132,7 @@ mod tests {
                 ..MemoryConfig::default()
             },
         );
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let command = CreateEntityCommand {
             entities: vec![MemoryEntity {
@@ -158,7 +160,7 @@ mod tests {
                 ..MemoryConfig::default()
             },
         );
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let command = CreateEntityCommand {
             entities: vec![

--- a/crates/mm-core/src/operations/create_relationship.rs
+++ b/crates/mm-core/src/operations/create_relationship.rs
@@ -1,5 +1,6 @@
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
+use mm_git::GitServiceTrait;
 use mm_memory::{MemoryRelationship, MemoryRepository};
 use tracing::instrument;
 
@@ -11,13 +12,14 @@ pub struct CreateRelationshipCommand {
 pub type CreateRelationshipResult<E> = CoreResult<(), E>;
 
 #[instrument(skip(ports), fields(relationships_count = command.relationships.len()))]
-pub async fn create_relationship<R>(
-    ports: &Ports<R>,
+pub async fn create_relationship<R, G>(
+    ports: &Ports<R, G>,
     command: CreateRelationshipCommand,
 ) -> CreateRelationshipResult<R::Error>
 where
     R: MemoryRepository + Send + Sync,
     R::Error: std::error::Error + Send + Sync + 'static,
+    G: GitServiceTrait + Send + Sync,
 {
     let errors = ports
         .memory_service
@@ -48,7 +50,7 @@ mod tests {
             .returning(|_| Ok(()));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let command = CreateRelationshipCommand {
             relationships: vec![MemoryRelationship {
@@ -68,7 +70,7 @@ mod tests {
         let mut mock = MockMemoryRepository::new();
         mock.expect_create_relationships().never();
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let command = CreateRelationshipCommand {
             relationships: vec![MemoryRelationship {
@@ -91,7 +93,7 @@ mod tests {
         let mut mock = MockMemoryRepository::new();
         mock.expect_create_relationships().never();
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let command = CreateRelationshipCommand {
             relationships: vec![MemoryRelationship {
@@ -114,7 +116,7 @@ mod tests {
         let mut mock = MockMemoryRepository::new();
         mock.expect_create_relationships().never();
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let command = CreateRelationshipCommand {
             relationships: vec![MemoryRelationship {
@@ -138,7 +140,7 @@ mod tests {
         mock.expect_create_relationships().never();
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let command = CreateRelationshipCommand {
             relationships: vec![

--- a/crates/mm-core/src/operations/get_entity.rs
+++ b/crates/mm-core/src/operations/get_entity.rs
@@ -2,6 +2,7 @@ use crate::MemoryEntity;
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
 use crate::validate_name;
+use mm_git::GitServiceTrait;
 use mm_memory::MemoryRepository;
 use tracing::instrument;
 
@@ -26,10 +27,14 @@ pub type GetEntityResult<E> = CoreResult<Option<MemoryEntity>, E>;
 ///
 /// The entity if found, or None if not found
 #[instrument(skip(ports), fields(name = %command.name))]
-pub async fn get_entity<R>(ports: &Ports<R>, command: GetEntityCommand) -> GetEntityResult<R::Error>
+pub async fn get_entity<R, G>(
+    ports: &Ports<R, G>,
+    command: GetEntityCommand,
+) -> GetEntityResult<R::Error>
 where
     R: MemoryRepository + Send + Sync,
     R::Error: std::error::Error + Send + Sync + 'static,
+    G: GitServiceTrait + Send + Sync,
 {
     // Validate command
     validate_name!(command.name);
@@ -64,7 +69,7 @@ mod tests {
             .returning(move |_| Ok(Some(entity.clone())));
 
         let service = MemoryService::new(mock_repo, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
         let command = GetEntityCommand {
             name: "test:entity".to_string(),
         };
@@ -79,7 +84,7 @@ mod tests {
         let mut mock_repo = MockMemoryRepository::new();
         mock_repo.expect_find_entity_by_name().never();
         let service = MemoryService::new(mock_repo, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let command = GetEntityCommand {
             name: "".to_string(),
@@ -103,7 +108,7 @@ mod tests {
             .returning(|_| Err(MemoryError::query_error("db error")));
 
         let service = MemoryService::new(mock_repo, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let command = GetEntityCommand {
             name: "test:entity".to_string(),
@@ -123,7 +128,7 @@ mod tests {
             .returning(|_| Ok(None));
 
         let service = MemoryService::new(mock_repo, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let command = GetEntityCommand {
             name: "missing:entity".to_string(),
@@ -147,7 +152,7 @@ mod tests {
                 .withf(move |n| n == name_clone)
                 .returning(|_| Ok(None));
             let service = MemoryService::new(mock_repo, MemoryConfig::default());
-            let ports = Ports::new(Arc::new(service));
+            let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
             let command = GetEntityCommand { name };
             let result = rt.block_on(get_entity(&ports, command));
             assert!(result.is_ok());
@@ -161,7 +166,7 @@ mod tests {
             let mut mock_repo = MockMemoryRepository::new();
             mock_repo.expect_find_entity_by_name().never();
             let service = MemoryService::new(mock_repo, MemoryConfig::default());
-            let ports = Ports::new(Arc::new(service));
+            let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
             let command = GetEntityCommand {
                 name: String::default(),
             };

--- a/crates/mm-core/src/operations/get_git_status.rs
+++ b/crates/mm-core/src/operations/get_git_status.rs
@@ -1,0 +1,67 @@
+use mm_git::{GitServiceTrait, RepositoryStatus};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tracing::instrument;
+
+use crate::error::{CoreError, CoreResult};
+use crate::ports::Ports;
+
+/// Command for retrieving git status
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct GetGitStatusCommand {
+    /// Path to the repository (optional, defaults to current directory)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
+
+pub type GetGitStatusResult<E> = CoreResult<RepositoryStatus, E>;
+
+/// Get git repository status
+#[instrument(skip(ports), err)]
+pub async fn get_git_status<R, G>(
+    ports: &Ports<R, G>,
+    command: GetGitStatusCommand,
+) -> GetGitStatusResult<R::Error>
+where
+    R: mm_memory::MemoryRepository + Send + Sync,
+    R::Error: std::error::Error + Send + Sync + 'static,
+    G: GitServiceTrait + Send + Sync,
+{
+    let service = &ports.git_service;
+
+    let path = command
+        .path
+        .as_deref()
+        .map(std::path::Path::new)
+        .unwrap_or_else(|| std::path::Path::new("."));
+
+    service.get_status(path).map_err(CoreError::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mm_git::{GitError, GitRepository, GitService, RepositoryStatus};
+    use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
+    use std::path::Path;
+    use std::sync::Arc;
+
+    struct MockGitRepo;
+    impl GitRepository for MockGitRepo {
+        fn get_status(&self, _path: &Path) -> Result<RepositoryStatus, GitError> {
+            Ok(RepositoryStatus::default())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_git_status() {
+        let mock_repo = MockMemoryRepository::new();
+        let memory_service = MemoryService::new(mock_repo, MemoryConfig::default());
+        let git_service = GitService::new(MockGitRepo);
+        let ports = Ports::new(Arc::new(memory_service), Arc::new(git_service));
+
+        let cmd = GetGitStatusCommand { path: None };
+        let res = get_git_status(&ports, cmd).await;
+        assert!(res.is_ok());
+    }
+}

--- a/crates/mm-core/src/operations/mod.rs
+++ b/crates/mm-core/src/operations/mod.rs
@@ -4,6 +4,7 @@ pub mod add_observations;
 pub mod create_entity;
 pub mod create_relationship;
 pub mod get_entity;
+pub mod get_git_status;
 pub mod get_project_context;
 pub mod list_projects;
 pub mod remove_all_observations;
@@ -18,6 +19,7 @@ pub use create_relationship::{
     CreateRelationshipCommand, CreateRelationshipResult, create_relationship,
 };
 pub use get_entity::{GetEntityCommand, GetEntityResult, get_entity};
+pub use get_git_status::{GetGitStatusCommand, GetGitStatusResult, get_git_status};
 pub use get_project_context::{
     GetProjectContextCommand, GetProjectContextResult, ProjectFilter, get_project_context,
 };

--- a/crates/mm-core/src/operations/remove_observations.rs
+++ b/crates/mm-core/src/operations/remove_observations.rs
@@ -1,6 +1,7 @@
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
 use crate::validate_name;
+use mm_git::GitServiceTrait;
 use mm_memory::MemoryRepository;
 use tracing::instrument;
 
@@ -13,13 +14,14 @@ pub struct RemoveObservationsCommand {
 pub type RemoveObservationsResult<E> = CoreResult<(), E>;
 
 #[instrument(skip(ports), fields(name = %command.name, observations_count = command.observations.len()))]
-pub async fn remove_observations<R>(
-    ports: &Ports<R>,
+pub async fn remove_observations<R, G>(
+    ports: &Ports<R, G>,
     command: RemoveObservationsCommand,
 ) -> RemoveObservationsResult<R::Error>
 where
     R: MemoryRepository + Send + Sync,
     R::Error: std::error::Error + Send + Sync + 'static,
+    G: GitServiceTrait + Send + Sync,
 {
     validate_name!(command.name);
 
@@ -45,7 +47,7 @@ mod tests {
             .withf(|name, obs| name == "test:entity" && obs.len() == 1)
             .returning(|_, _| Ok(()));
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
         let command = RemoveObservationsCommand {
             name: "test:entity".to_string(),
             observations: vec!["obs".to_string()],
@@ -59,7 +61,7 @@ mod tests {
         let mut mock = MockMemoryRepository::new();
         mock.expect_remove_observations().never();
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
         let command = RemoveObservationsCommand {
             name: "".to_string(),
             observations: vec![],
@@ -78,7 +80,7 @@ mod tests {
             .withf(|name, _| name == "test:entity")
             .returning(|_, _| Err(MemoryError::runtime_error("fail")));
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
         let command = RemoveObservationsCommand {
             name: "test:entity".to_string(),
             observations: vec!["obs".to_string()],
@@ -102,7 +104,7 @@ mod tests {
                 .withf(move |n, o| n == name_clone && o == obs_clone.as_slice())
                 .returning(|_, _| Ok(()));
             let service = MemoryService::new(mock, MemoryConfig::default());
-            let ports = Ports::new(Arc::new(service));
+            let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
             let command = RemoveObservationsCommand { name, observations };
             let result = rt.block_on(remove_observations(&ports, command));
             assert!(result.is_ok());
@@ -117,7 +119,7 @@ mod tests {
             let mut mock = MockMemoryRepository::new();
             mock.expect_remove_observations().never();
             let service = MemoryService::new(mock, MemoryConfig::default());
-            let ports = Ports::new(Arc::new(service));
+            let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
             let command = RemoveObservationsCommand {
                 name: String::default(),
                 observations,

--- a/crates/mm-core/src/operations/update_entity.rs
+++ b/crates/mm-core/src/operations/update_entity.rs
@@ -1,6 +1,7 @@
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
 use crate::validate_name;
+use mm_git::GitServiceTrait;
 use mm_memory::{EntityUpdate, MemoryRepository};
 use tracing::instrument;
 
@@ -13,13 +14,14 @@ pub struct UpdateEntityCommand {
 pub type UpdateEntityResult<E> = CoreResult<(), E>;
 
 #[instrument(skip(ports), fields(name = %command.name))]
-pub async fn update_entity<R>(
-    ports: &Ports<R>,
+pub async fn update_entity<R, G>(
+    ports: &Ports<R, G>,
     command: UpdateEntityCommand,
 ) -> UpdateEntityResult<R::Error>
 where
     R: MemoryRepository + Send + Sync,
     R::Error: std::error::Error + Send + Sync + 'static,
+    G: GitServiceTrait + Send + Sync,
 {
     validate_name!(command.name);
 
@@ -43,7 +45,7 @@ mod tests {
             .withf(|n, _| n == "test:entity")
             .returning(|_, _| Ok(()));
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
         let cmd = UpdateEntityCommand {
             name: "test:entity".into(),
             update: EntityUpdate::default(),
@@ -57,7 +59,7 @@ mod tests {
         let mut mock = MockMemoryRepository::new();
         mock.expect_update_entity().never();
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
         let cmd = UpdateEntityCommand {
             name: "".into(),
             update: EntityUpdate::default(),

--- a/crates/mm-core/src/ports.rs
+++ b/crates/mm-core/src/ports.rs
@@ -1,3 +1,4 @@
+use mm_git::GitServiceTrait;
 use mm_memory::{MemoryRepository, MemoryService};
 use std::sync::{Arc, RwLock};
 
@@ -7,35 +8,42 @@ use crate::RootCollection;
 ///
 /// This struct serves as a dependency injection container for all operations.
 /// Each operation function will receive this struct to access the services it needs.
-pub struct Ports<R>
+pub struct Ports<R, G>
 where
     R: MemoryRepository + Send + Sync + 'static,
+    G: GitServiceTrait + Send + Sync + 'static,
 {
     /// Memory service for entity operations
     pub memory_service: Arc<MemoryService<R>>,
+    /// Git service for repository operations
+    pub git_service: Arc<G>,
     /// Collection of client-provided roots
     pub roots: Arc<RwLock<RootCollection>>,
 }
 
-impl<R> Ports<R>
+impl<R, G> Ports<R, G>
 where
     R: MemoryRepository + Send + Sync + 'static,
+    G: GitServiceTrait + Send + Sync + 'static,
 {
-    /// Create a new Ports instance with the given memory service and roots
+    /// Create a new Ports instance with the given memory and git services and roots
     pub fn with_roots(
         memory_service: Arc<MemoryService<R>>,
+        git_service: Arc<G>,
         roots: Arc<RwLock<RootCollection>>,
     ) -> Self {
         Self {
             memory_service,
+            git_service,
             roots,
         }
     }
 
-    /// Backwards-compatible constructor that creates empty roots
-    pub fn new(memory_service: Arc<MemoryService<R>>) -> Self {
+    /// Create a Ports instance with default empty roots
+    pub fn new(memory_service: Arc<MemoryService<R>>, git_service: Arc<G>) -> Self {
         Self::with_roots(
             memory_service,
+            git_service,
             Arc::new(RwLock::new(RootCollection::default())),
         )
     }

--- a/crates/mm-git-libgit2/Cargo.toml
+++ b/crates/mm-git-libgit2/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "mm-git-libgit2"
+version = "0.1.0"
+edition = "2024"
+license = "MPL-2.0"
+
+[dependencies]
+mm-git = { path = "../mm-git" }
+thiserror = { workspace = true }
+git2 = "0.18.1"

--- a/crates/mm-git-libgit2/src/lib.rs
+++ b/crates/mm-git-libgit2/src/lib.rs
@@ -1,0 +1,88 @@
+use git2::{Repository, Status, StatusOptions};
+use mm_git::{GitError, GitRepository, RepositoryStatus};
+use std::path::{Path, PathBuf};
+
+pub struct LibGit2Repository;
+
+impl Default for LibGit2Repository {
+    fn default() -> Self {
+        Self
+    }
+}
+
+impl LibGit2Repository {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl GitRepository for LibGit2Repository {
+    fn get_status(&self, path: &Path) -> Result<RepositoryStatus, GitError> {
+        let repo = Repository::open(path).map_err(|e| GitError::RepositoryError {
+            message: e.message().to_string(),
+            source: None,
+        })?;
+        let head = repo.head().ok();
+        let branch = head
+            .as_ref()
+            .and_then(|h| h.shorthand())
+            .unwrap_or("HEAD")
+            .to_string();
+
+        let remote_url = repo
+            .find_remote("origin")
+            .ok()
+            .and_then(|r| r.url().map(|u| u.to_string()));
+
+        let mut opts = StatusOptions::new();
+        opts.include_untracked(true).recurse_untracked_dirs(true);
+        let statuses = repo
+            .statuses(Some(&mut opts))
+            .map_err(|e| GitError::RepositoryError {
+                message: e.message().to_string(),
+                source: None,
+            })?;
+
+        let mut untracked = Vec::new();
+        let mut modified = Vec::new();
+        let mut staged = Vec::new();
+        let mut is_dirty = false;
+
+        for entry in statuses.iter() {
+            let status = entry.status();
+            let path = entry.path().map(PathBuf::from).unwrap_or_default();
+            if status.contains(Status::WT_NEW) {
+                is_dirty = true;
+                untracked.push(path.clone());
+            }
+            if status.intersects(
+                Status::WT_MODIFIED
+                    | Status::WT_DELETED
+                    | Status::WT_RENAMED
+                    | Status::WT_TYPECHANGE,
+            ) {
+                is_dirty = true;
+                modified.push(path.clone());
+            }
+            if status.intersects(
+                Status::INDEX_MODIFIED
+                    | Status::INDEX_NEW
+                    | Status::INDEX_DELETED
+                    | Status::INDEX_RENAMED
+                    | Status::INDEX_TYPECHANGE,
+            ) {
+                is_dirty = true;
+                staged.push(path);
+            }
+        }
+
+        Ok(RepositoryStatus {
+            current_branch: branch,
+            remote_url,
+            is_dirty,
+            untracked_files: untracked,
+            modified_files: modified,
+            staged_files: staged,
+        })
+    }
+}

--- a/crates/mm-git/Cargo.toml
+++ b/crates/mm-git/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "mm-git"
+version = "0.1.0"
+edition = "2024"
+license = "MPL-2.0"
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+thiserror = { workspace = true }
+schemars = { workspace = true }

--- a/crates/mm-git/src/lib.rs
+++ b/crates/mm-git/src/lib.rs
@@ -1,0 +1,70 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::error::Error as StdError;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum GitError {
+    /// Generic repository error
+    #[error("Repository error: {message}")]
+    RepositoryError {
+        message: String,
+        #[source]
+        source: Option<Box<dyn StdError + Send + Sync>>,
+    },
+}
+
+pub type GitResult<T> = Result<T, GitError>;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+pub struct RepositoryStatus {
+    pub current_branch: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote_url: Option<String>,
+    pub is_dirty: bool,
+    pub untracked_files: Vec<PathBuf>,
+    pub modified_files: Vec<PathBuf>,
+    pub staged_files: Vec<PathBuf>,
+}
+
+pub trait GitRepository: Send + Sync {
+    fn get_status(&self, path: &Path) -> GitResult<RepositoryStatus>;
+}
+
+pub struct GitService<R: GitRepository> {
+    repository: R,
+}
+
+impl<R: GitRepository> GitService<R> {
+    pub fn new(repository: R) -> Self {
+        Self { repository }
+    }
+
+    pub fn get_status(&self, path: &Path) -> GitResult<RepositoryStatus> {
+        self.repository.get_status(path)
+    }
+}
+
+pub trait GitServiceTrait: Send + Sync {
+    fn get_status(&self, path: &Path) -> GitResult<RepositoryStatus>;
+}
+
+impl<R: GitRepository> GitServiceTrait for GitService<R> {
+    fn get_status(&self, path: &Path) -> GitResult<RepositoryStatus> {
+        self.get_status(path)
+    }
+}
+
+/// No-op Git service used when no real Git integration is configured.
+#[derive(Debug, Clone, Default)]
+pub struct NoopGitService;
+
+impl GitServiceTrait for NoopGitService {
+    fn get_status(&self, _path: &Path) -> GitResult<RepositoryStatus> {
+        Err(GitError::RepositoryError {
+            message: "Git service not configured".into(),
+            source: None,
+        })
+    }
+}

--- a/crates/mm-server/Cargo.toml
+++ b/crates/mm-server/Cargo.toml
@@ -14,6 +14,8 @@ mm-core = { path = "../mm-core" }
 mm-memory-neo4j = { path = "../mm-memory-neo4j" }
 mm-memory = { path = "../mm-memory" }
 mm-utils = { path = "../mm-utils" }
+mm-git = { path = "../mm-git" }
+mm-git-libgit2 = { path = "../mm-git-libgit2" }
 tokio = { workspace = true, features = ["full"] }
 rust-mcp-sdk = { workspace = true }
 serde = { workspace = true }

--- a/crates/mm-server/src/mcp/add_observations.rs
+++ b/crates/mm-server/src/mcp/add_observations.rs
@@ -37,7 +37,7 @@ mod tests {
             .returning(|_, _| Ok(()));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let tool = AddObservationsTool {
             name: "test:entity".to_string(),
@@ -56,7 +56,7 @@ mod tests {
             .returning(|_, _| Err(MemoryError::runtime_error("fail")));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let tool = AddObservationsTool {
             name: "test:entity".to_string(),

--- a/crates/mm-server/src/mcp/create_entity.rs
+++ b/crates/mm-server/src/mcp/create_entity.rs
@@ -53,7 +53,7 @@ mod tests {
                 ..MemoryConfig::default()
             },
         );
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let tool = CreateEntityTool {
             entities: vec![MemoryEntity {
@@ -84,7 +84,7 @@ mod tests {
             .returning(|_| Err(MemoryError::runtime_error("fail")));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let tool = CreateEntityTool {
             entities: vec![MemoryEntity {

--- a/crates/mm-server/src/mcp/create_relationship.rs
+++ b/crates/mm-server/src/mcp/create_relationship.rs
@@ -69,7 +69,7 @@ mod tests {
             .returning(|_| Ok(()));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let tool = CreateRelationshipTool {
             relationships: vec![RelationshipInput {
@@ -92,7 +92,7 @@ mod tests {
             .returning(|_| Err(MemoryError::runtime_error("fail")));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let tool = CreateRelationshipTool {
             relationships: vec![RelationshipInput {

--- a/crates/mm-server/src/mcp/error.rs
+++ b/crates/mm-server/src/mcp/error.rs
@@ -54,6 +54,8 @@ where
                 .map(|(name, err)| format!("{}: {}", name, err))
                 .collect::<Vec<_>>()
                 .join("; "),
+            CoreError::Git(e) => e.to_string(),
+            CoreError::GitNotConfigured => "Git service not configured".to_string(),
         };
         Self::with_source(message, error)
     }

--- a/crates/mm-server/src/mcp/get_entity.rs
+++ b/crates/mm-server/src/mcp/get_entity.rs
@@ -62,7 +62,7 @@ mod tests {
             .returning(move |_| Ok(Some(entity.clone())));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let tool = GetEntityTool {
             name: "test:entity".to_string(),
@@ -82,7 +82,7 @@ mod tests {
             .returning(|_| Err(MemoryError::query_error("fail")));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let tool = GetEntityTool {
             name: "test:entity".to_string(),
@@ -100,7 +100,7 @@ mod tests {
             .returning(|_| Ok(None));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let tool = GetEntityTool {
             name: "missing".to_string(),

--- a/crates/mm-server/src/mcp/get_project_context.rs
+++ b/crates/mm-server/src/mcp/get_project_context.rs
@@ -109,7 +109,7 @@ mod tests {
 
         // Create service and ports
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         // Create and call tool
         let tool = GetProjectContextTool {
@@ -130,7 +130,7 @@ mod tests {
     async fn test_call_tool_missing_parameters() {
         let mock = MockMemoryRepository::new();
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let tool = GetProjectContextTool {
             project_name: None,

--- a/crates/mm-server/src/mcp/git_status.rs
+++ b/crates/mm-server/src/mcp/git_status.rs
@@ -1,0 +1,56 @@
+use mm_core::{GetGitStatusCommand, get_git_status};
+use mm_utils::IntoJsonSchema;
+use rust_mcp_sdk::macros::mcp_tool;
+use serde::{Deserialize, Serialize};
+
+/// MCP tool for retrieving git repository status
+#[mcp_tool(name = "git_status", description = "Get status of a Git repository")]
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct GitStatusTool {
+    /// Path to the repository (optional, defaults to current directory)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
+
+impl GitStatusTool {
+    generate_call_tool!(
+        self,
+        GetGitStatusCommand { path => self.path.clone() },
+        get_git_status,
+        |_cmd, status| {
+            serde_json::to_value(status).map(|json| {
+                rust_mcp_sdk::schema::CallToolResult::text_content(json.to_string(), None)
+            }).map_err(|e| rust_mcp_sdk::schema::schema_utils::CallToolError::new(crate::mcp::error::ToolError::from(e)))
+        }
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mm_core::{MemoryService, Ports};
+    use mm_git::{GitError, GitRepository, GitService, RepositoryStatus};
+    use mm_memory::{MemoryConfig, MockMemoryRepository};
+    use std::path::Path;
+    use std::sync::Arc;
+
+    struct MockGitRepo;
+    impl GitRepository for MockGitRepo {
+        fn get_status(&self, _path: &Path) -> Result<RepositoryStatus, GitError> {
+            Ok(RepositoryStatus::default())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_call_tool() {
+        let mut mock_memory = MockMemoryRepository::new();
+        mock_memory.expect_create_entities().returning(|_| Ok(()));
+        let memory_service = MemoryService::new(mock_memory, MemoryConfig::default());
+        let git_service = GitService::new(MockGitRepo);
+        let ports = Ports::new(Arc::new(memory_service), Arc::new(git_service));
+
+        let tool = GitStatusTool { path: None };
+        let res = tool.call_tool(&ports).await;
+        assert!(res.is_ok());
+    }
+}

--- a/crates/mm-server/src/mcp/list_projects.rs
+++ b/crates/mm-server/src/mcp/list_projects.rs
@@ -70,7 +70,7 @@ mod tests {
             .returning(move |_, _, _| Ok(vec![project1.clone(), project2.clone()]));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let tool = ListProjectsTool { name_filter: None };
 
@@ -110,7 +110,7 @@ mod tests {
             .returning(move |_, _, _| Ok(vec![project1.clone(), project2.clone()]));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let tool = ListProjectsTool {
             name_filter: Some("flakes".to_string()),

--- a/crates/mm-server/src/mcp/macros.rs
+++ b/crates/mm-server/src/mcp/macros.rs
@@ -33,10 +33,11 @@ macro_rules! generate_call_tool {
 
     // Custom success block version that provides both the command and the result
     ($self_ident:ident, $command:ident { $( $field:ident $(=> $value:expr)? ),* $(,)? }, $operation:path, |$cmd_ident:ident, $res_ident:ident| $success_block:block) => {
-        pub async fn call_tool<R>(&$self_ident, ports: &mm_core::Ports<R>) -> Result<rust_mcp_sdk::schema::CallToolResult, rust_mcp_sdk::schema::schema_utils::CallToolError>
+        pub async fn call_tool<R, G>(&$self_ident, ports: &mm_core::Ports<R, G>) -> Result<rust_mcp_sdk::schema::CallToolResult, rust_mcp_sdk::schema::schema_utils::CallToolError>
         where
             R: mm_memory::MemoryRepository + Send + Sync,
             R::Error: std::error::Error + Send + Sync + 'static,
+            G: mm_git::GitServiceTrait + Send + Sync,
         {
             use tracing::Instrument;
 

--- a/crates/mm-server/src/mcp/mod.rs
+++ b/crates/mm-server/src/mcp/mod.rs
@@ -6,6 +6,7 @@ pub mod create_relationship;
 pub mod error;
 pub mod get_entity;
 pub mod get_project_context;
+pub mod git_status;
 pub mod list_projects;
 pub mod remove_all_observations;
 pub mod remove_observations;
@@ -20,6 +21,7 @@ pub use create_entity::CreateEntityTool;
 pub use create_relationship::CreateRelationshipTool;
 pub use get_entity::GetEntityTool;
 pub use get_project_context::GetProjectContextTool;
+pub use git_status::GitStatusTool;
 pub use list_projects::ListProjectsTool;
 pub use remove_all_observations::RemoveAllObservationsTool;
 pub use remove_observations::RemoveObservationsTool;
@@ -41,6 +43,7 @@ tool_box!(
         GetProjectContextTool,
         ListProjectsTool,
         UpdateEntityTool,
-        UpdateRelationshipTool
+        UpdateRelationshipTool,
+        GitStatusTool
     ]
 );

--- a/crates/mm-server/src/mcp/remove_all_observations.rs
+++ b/crates/mm-server/src/mcp/remove_all_observations.rs
@@ -36,7 +36,7 @@ mod tests {
             .returning(|_| Ok(()));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let tool = RemoveAllObservationsTool {
             name: "test:entity".to_string(),
@@ -55,7 +55,7 @@ mod tests {
             .returning(|_| Err(MemoryError::runtime_error("fail")));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let tool = RemoveAllObservationsTool {
             name: "test:entity".to_string(),

--- a/crates/mm-server/src/mcp/remove_observations.rs
+++ b/crates/mm-server/src/mcp/remove_observations.rs
@@ -37,7 +37,7 @@ mod tests {
             .returning(|_, _| Ok(()));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let tool = RemoveObservationsTool {
             name: "test:entity".to_string(),
@@ -56,7 +56,7 @@ mod tests {
             .returning(|_, _| Err(MemoryError::runtime_error("fail")));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let tool = RemoveObservationsTool {
             name: "test:entity".to_string(),

--- a/crates/mm-server/src/mcp/set_observations.rs
+++ b/crates/mm-server/src/mcp/set_observations.rs
@@ -37,7 +37,7 @@ mod tests {
             .returning(|_, _| Ok(()));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let tool = SetObservationsTool {
             name: "test:entity".to_string(),
@@ -56,7 +56,7 @@ mod tests {
             .returning(|_, _| Err(MemoryError::runtime_error("fail")));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
 
         let tool = SetObservationsTool {
             name: "test:entity".to_string(),

--- a/crates/mm-server/src/mcp/update_entity.rs
+++ b/crates/mm-server/src/mcp/update_entity.rs
@@ -36,7 +36,7 @@ mod tests {
             .withf(|n, _| n == "e")
             .returning(|_, _| Ok(()));
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
         let tool = UpdateEntityTool {
             name: "e".into(),
             update: EntityUpdate::default(),

--- a/crates/mm-server/src/mcp/update_relationship.rs
+++ b/crates/mm-server/src/mcp/update_relationship.rs
@@ -53,7 +53,7 @@ mod tests {
             .withf(|f, t, n, _| f == "a" && t == "b" && n == "rel")
             .returning(|_, _, _, _| Ok(()));
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(mm_git::NoopGitService));
         let tool = UpdateRelationshipTool {
             from: "a".into(),
             to: "b".into(),

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,7 @@
             buildInputs = with pkgs; [
               openssl
               openssl.dev
+              libgit2
             ];
             overrideMain = old: {
               preConfigure = (old.preConfigure or "") + ''
@@ -51,13 +52,16 @@
         in
         {
           default = pkgs.mkShell {
+            nativeBuildInputs = with pkgs; [
+              libgit2
+              pkg-config
+            ];
             buildInputs = with pkgs; [
               rustToolchain
               rust-analyzer
               clippy
               rustfmt
               cmake
-              pkg-config
               openssl
               openssl.dev
               nodejs


### PR DESCRIPTION
## Summary
- expose Git status via new mm-git and libgit2 adapter crates
- integrate Git service into Ports struct and mm-server
- register `git_status` MCP tool
- document new tool in README

## Testing
- `just validate`


------
https://chatgpt.com/codex/tasks/task_e_685a17ae273883279e36348ea91baeda