### PR TITLE
Implement task operations

### DIFF
--- a/crates/mm-core/src/error.rs
+++ b/crates/mm-core/src/error.rs
@@ -19,6 +19,10 @@ where
     /// Multiple validation errors grouped by name
     #[error("Batch validation error")]
     BatchValidation(Vec<(String, mm_memory::ValidationError)>),
+
+    /// Error when a project name is required but not provided
+    #[error("No project specified")]
+    MissingProject,
 }
 
 /// Result type for mm-core

--- a/crates/mm-core/src/lib.rs
+++ b/crates/mm-core/src/lib.rs
@@ -15,15 +15,17 @@ pub use error::{CoreError, CoreResult};
 pub use mm_memory::MemoryService;
 pub use operations::{
     CreateEntitiesCommand, CreateEntitiesResult, CreateRelationshipsCommand,
-    CreateRelationshipsResult, DeleteEntitiesCommand, DeleteEntitiesResult,
-    DeleteRelationshipsCommand, DeleteRelationshipsResult, FindEntitiesByLabelsCommand,
-    FindEntitiesByLabelsResult, FindEntitiesByLabelsResultType, FindRelationshipsCommand,
-    FindRelationshipsResult, FindRelationshipsResultType, GetEntityCommand, GetEntityResult,
-    GetProjectContextCommand, GetProjectContextResult, ListProjectsCommand, ListProjectsResult,
-    ProjectFilter, UpdateEntityCommand, UpdateEntityResult, UpdateRelationshipCommand,
-    UpdateRelationshipResult, create_entities, create_relationships, delete_entities,
-    delete_relationships, find_entities_by_labels, find_relationships, get_entity,
-    get_project_context, list_projects, update_entity, update_relationship,
+    CreateRelationshipsResult, CreateTaskCommand, CreateTaskResult, DeleteEntitiesCommand,
+    DeleteEntitiesResult, DeleteRelationshipsCommand, DeleteRelationshipsResult, DeleteTaskCommand,
+    DeleteTaskResult, FindEntitiesByLabelsCommand, FindEntitiesByLabelsResult,
+    FindEntitiesByLabelsResultType, FindRelationshipsCommand, FindRelationshipsResult,
+    FindRelationshipsResultType, GetEntityCommand, GetEntityResult, GetProjectContextCommand,
+    GetProjectContextResult, GetTaskCommand, GetTaskResult, ListProjectsCommand,
+    ListProjectsResult, ProjectFilter, UpdateEntityCommand, UpdateEntityResult,
+    UpdateRelationshipCommand, UpdateRelationshipResult, UpdateTaskCommand, UpdateTaskResult,
+    create_entities, create_relationships, create_task, delete_entities, delete_relationships,
+    delete_task, find_entities_by_labels, find_relationships, get_entity, get_project_context,
+    get_task, list_projects, update_entity, update_relationship, update_task,
 };
 pub use ports::Ports;
 pub use root::{Root, RootCollection};

--- a/crates/mm-core/src/operations/mod.rs
+++ b/crates/mm-core/src/operations/mod.rs
@@ -35,7 +35,11 @@ pub use get_project_context::{
     GetProjectContextCommand, GetProjectContextResult, ProjectFilter, get_project_context,
 };
 pub use list_projects::{ListProjectsCommand, ListProjectsResult, list_projects};
-pub use tasks::{Priority, TaskProperties, TaskStatus, TaskType};
+pub use tasks::{
+    CreateTaskCommand, CreateTaskResult, DeleteTaskCommand, DeleteTaskResult, GetTaskCommand,
+    GetTaskResult, Priority, TaskProperties, TaskStatus, TaskType, UpdateTaskCommand,
+    UpdateTaskResult, create_task, delete_task, get_task, update_task,
+};
 pub use update_entity::{UpdateEntityCommand, UpdateEntityResult, update_entity};
 pub use update_relationship::{
     UpdateRelationshipCommand, UpdateRelationshipResult, update_relationship,

--- a/crates/mm-core/src/operations/tasks/create_task.rs
+++ b/crates/mm-core/src/operations/tasks/create_task.rs
@@ -1,0 +1,164 @@
+use super::types::TaskProperties;
+use crate::error::{CoreError, CoreResult};
+use crate::ports::Ports;
+use crate::validate_name;
+use crate::{MemoryEntity, MemoryRelationship};
+use mm_memory::MemoryRepository;
+use std::collections::HashMap;
+use tracing::instrument;
+
+#[derive(Debug, Clone)]
+pub struct CreateTaskCommand {
+    pub task: MemoryEntity<TaskProperties>,
+    pub project_name: Option<String>,
+}
+
+pub type CreateTaskResult<E> = CoreResult<(), E>;
+
+#[instrument(skip(ports), fields(task_name = %command.task.name))]
+pub async fn create_task<R>(
+    ports: &Ports<R>,
+    command: CreateTaskCommand,
+) -> CreateTaskResult<R::Error>
+where
+    R: MemoryRepository + Send + Sync,
+    R::Error: std::error::Error + Send + Sync + 'static,
+{
+    validate_name!(command.task.name);
+
+    let project_name = match command
+        .project_name
+        .or_else(|| ports.memory_service.memory_config().default_project.clone())
+    {
+        Some(p) => p,
+        None => return Err(CoreError::MissingProject),
+    };
+
+    let task = command.task;
+    let task_name = task.name.clone();
+
+    let errors = ports
+        .memory_service
+        .create_entities_typed(std::slice::from_ref(&task))
+        .await
+        .map_err(CoreError::from)?;
+
+    if !errors.is_empty() {
+        return Err(CoreError::BatchValidation(errors));
+    }
+
+    let relationship = MemoryRelationship {
+        from: project_name,
+        to: task_name,
+        name: "contains".to_string(),
+        properties: HashMap::default(),
+    };
+
+    let errors = ports
+        .memory_service
+        .create_relationships(std::slice::from_ref(&relationship))
+        .await
+        .map_err(CoreError::from)?;
+
+    if !errors.is_empty() {
+        return Err(CoreError::BatchValidation(errors));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository, ValidationErrorKind};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_create_task_success() {
+        let mut mock = MockMemoryRepository::new();
+        mock.expect_create_entities()
+            .withf(|e| e.len() == 1 && e[0].name == "task:1")
+            .returning(|_| Ok(()));
+        mock.expect_create_relationships()
+            .withf(|r| {
+                r.len() == 1
+                    && r[0].from == "proj"
+                    && r[0].to == "task:1"
+                    && r[0].name == "contains"
+            })
+            .returning(|_| Ok(()));
+
+        let service = MemoryService::new(
+            mock,
+            MemoryConfig {
+                default_project: Some("proj".into()),
+                ..MemoryConfig::default()
+            },
+        );
+        let ports = Ports::new(Arc::new(service));
+
+        let cmd = CreateTaskCommand {
+            task: MemoryEntity::<TaskProperties> {
+                name: "task:1".into(),
+                labels: vec!["Task".into()],
+                ..Default::default()
+            },
+            project_name: None,
+        };
+
+        let res = create_task(&ports, cmd).await;
+        assert!(res.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_create_task_missing_project() {
+        let mut mock = MockMemoryRepository::new();
+        mock.expect_create_entities().never();
+        mock.expect_create_relationships().never();
+
+        let service = MemoryService::new(mock, MemoryConfig::default());
+        let ports = Ports::new(Arc::new(service));
+
+        let cmd = CreateTaskCommand {
+            task: MemoryEntity::<TaskProperties> {
+                name: "task:1".into(),
+                labels: vec!["Task".into()],
+                ..Default::default()
+            },
+            project_name: None,
+        };
+
+        let res = create_task(&ports, cmd).await;
+        assert!(matches!(res, Err(CoreError::MissingProject)));
+    }
+
+    #[tokio::test]
+    async fn test_create_task_empty_name() {
+        let mut mock = MockMemoryRepository::new();
+        mock.expect_create_entities().never();
+        mock.expect_create_relationships().never();
+
+        let service = MemoryService::new(
+            mock,
+            MemoryConfig {
+                default_project: Some("proj".into()),
+                ..MemoryConfig::default()
+            },
+        );
+        let ports = Ports::new(Arc::new(service));
+
+        let cmd = CreateTaskCommand {
+            task: MemoryEntity::<TaskProperties> {
+                name: String::new(),
+                labels: vec!["Task".into()],
+                ..Default::default()
+            },
+            project_name: None,
+        };
+
+        let res = create_task(&ports, cmd).await;
+        assert!(
+            matches!(res, Err(CoreError::Validation(ref e)) if e.0.contains(&ValidationErrorKind::EmptyEntityName))
+        );
+    }
+}

--- a/crates/mm-core/src/operations/tasks/delete_task.rs
+++ b/crates/mm-core/src/operations/tasks/delete_task.rs
@@ -1,0 +1,71 @@
+use crate::error::{CoreError, CoreResult};
+use crate::ports::Ports;
+use crate::validate_name;
+use mm_memory::MemoryRepository;
+use tracing::instrument;
+
+#[derive(Debug, Clone)]
+pub struct DeleteTaskCommand {
+    pub name: String,
+}
+
+pub type DeleteTaskResult<E> = CoreResult<(), E>;
+
+#[instrument(skip(ports), fields(name = %command.name))]
+pub async fn delete_task<R>(
+    ports: &Ports<R>,
+    command: DeleteTaskCommand,
+) -> DeleteTaskResult<R::Error>
+where
+    R: MemoryRepository + Send + Sync,
+    R::Error: std::error::Error + Send + Sync + 'static,
+{
+    validate_name!(command.name);
+
+    let errors = ports
+        .memory_service
+        .delete_entities(std::slice::from_ref(&command.name))
+        .await
+        .map_err(CoreError::from)?;
+
+    if !errors.is_empty() {
+        return Err(CoreError::BatchValidation(errors));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_delete_task_success() {
+        let mut mock = MockMemoryRepository::new();
+        mock.expect_delete_entities()
+            .withf(|n| n.len() == 1 && n[0] == "task:1")
+            .returning(|_| Ok(()));
+        let service = MemoryService::new(mock, MemoryConfig::default());
+        let ports = Ports::new(Arc::new(service));
+        let cmd = DeleteTaskCommand {
+            name: "task:1".into(),
+        };
+        let res = delete_task(&ports, cmd).await;
+        assert!(res.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_delete_task_empty_name() {
+        let mut mock = MockMemoryRepository::new();
+        mock.expect_delete_entities().never();
+        let service = MemoryService::new(mock, MemoryConfig::default());
+        let ports = Ports::new(Arc::new(service));
+        let cmd = DeleteTaskCommand {
+            name: String::new(),
+        };
+        let res = delete_task(&ports, cmd).await;
+        assert!(matches!(res, Err(CoreError::Validation(_))));
+    }
+}

--- a/crates/mm-core/src/operations/tasks/get_task.rs
+++ b/crates/mm-core/src/operations/tasks/get_task.rs
@@ -1,0 +1,73 @@
+use super::types::TaskProperties;
+use crate::MemoryEntity;
+use crate::error::{CoreError, CoreResult};
+use crate::ports::Ports;
+use crate::validate_name;
+use mm_memory::MemoryRepository;
+use tracing::instrument;
+
+#[derive(Debug, Clone)]
+pub struct GetTaskCommand {
+    pub name: String,
+}
+
+pub type GetTaskResult<E> = CoreResult<Option<MemoryEntity<TaskProperties>>, E>;
+
+#[instrument(skip(ports), fields(name = %command.name))]
+pub async fn get_task<R>(ports: &Ports<R>, command: GetTaskCommand) -> GetTaskResult<R::Error>
+where
+    R: MemoryRepository + Send + Sync,
+    R::Error: std::error::Error + Send + Sync + 'static,
+{
+    validate_name!(command.name);
+
+    ports
+        .memory_service
+        .find_entity_by_name_typed::<TaskProperties>(&command.name)
+        .await
+        .map_err(CoreError::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
+    use mockall::predicate::*;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_get_task_success() {
+        let mut mock = MockMemoryRepository::new();
+        let entity = MemoryEntity {
+            name: "task:1".into(),
+            labels: vec!["Task".into()],
+            ..Default::default()
+        };
+        mock.expect_find_entity_by_name()
+            .with(eq("task:1"))
+            .returning(move |_| Ok(Some(entity.clone())));
+
+        let service = MemoryService::new(mock, MemoryConfig::default());
+        let ports = Ports::new(Arc::new(service));
+
+        let cmd = GetTaskCommand {
+            name: "task:1".into(),
+        };
+        let res = get_task(&ports, cmd).await.unwrap();
+        assert!(res.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_get_task_empty_name() {
+        let mut mock = MockMemoryRepository::new();
+        mock.expect_find_entity_by_name().never();
+        let service = MemoryService::new(mock, MemoryConfig::default());
+        let ports = Ports::new(Arc::new(service));
+
+        let cmd = GetTaskCommand {
+            name: String::new(),
+        };
+        let res = get_task(&ports, cmd).await;
+        assert!(matches!(res, Err(CoreError::Validation(_))));
+    }
+}

--- a/crates/mm-core/src/operations/tasks/mod.rs
+++ b/crates/mm-core/src/operations/tasks/mod.rs
@@ -1,3 +1,12 @@
 pub mod types;
 
+mod create_task;
+mod delete_task;
+mod get_task;
+mod update_task;
+
+pub use create_task::{CreateTaskCommand, CreateTaskResult, create_task};
+pub use delete_task::{DeleteTaskCommand, DeleteTaskResult, delete_task};
+pub use get_task::{GetTaskCommand, GetTaskResult, get_task};
 pub use types::{Priority, TaskProperties, TaskStatus, TaskType};
+pub use update_task::{UpdateTaskCommand, UpdateTaskResult, update_task};

--- a/crates/mm-core/src/operations/tasks/types.rs
+++ b/crates/mm-core/src/operations/tasks/types.rs
@@ -1,6 +1,9 @@
 use chrono::{DateTime, Utc};
+use mm_memory::MemoryValue;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use serde_json;
+use std::collections::HashMap;
 
 /// Priority level for a task
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
@@ -56,4 +59,117 @@ pub struct TaskProperties {
 
     /// Task priority
     pub priority: Priority,
+}
+
+impl Default for TaskProperties {
+    fn default() -> Self {
+        TaskProperties {
+            description: String::new(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            due_date: None,
+            task_type: TaskType::Feature,
+            status: TaskStatus::Todo,
+            priority: Priority::Medium,
+        }
+    }
+}
+
+impl From<HashMap<String, MemoryValue>> for TaskProperties {
+    fn from(mut map: HashMap<String, MemoryValue>) -> Self {
+        let description = match map.remove("description") {
+            Some(MemoryValue::String(s)) => s,
+            Some(v) => v.to_string(),
+            None => String::new(),
+        };
+
+        let created_at = match map.remove("created_at") {
+            Some(MemoryValue::DateTime(dt)) => dt.with_timezone(&Utc),
+            Some(MemoryValue::String(s)) => DateTime::parse_from_rfc3339(&s)
+                .map(|dt| dt.with_timezone(&Utc))
+                .unwrap_or_else(|_| Utc::now()),
+            _ => Utc::now(),
+        };
+
+        let updated_at = match map.remove("updated_at") {
+            Some(MemoryValue::DateTime(dt)) => dt.with_timezone(&Utc),
+            Some(MemoryValue::String(s)) => DateTime::parse_from_rfc3339(&s)
+                .map(|dt| dt.with_timezone(&Utc))
+                .unwrap_or_else(|_| Utc::now()),
+            _ => Utc::now(),
+        };
+
+        let due_date = match map.remove("due_date") {
+            Some(MemoryValue::DateTime(dt)) => Some(dt.with_timezone(&Utc)),
+            Some(MemoryValue::String(s)) => DateTime::parse_from_rfc3339(&s)
+                .map(|dt| dt.with_timezone(&Utc))
+                .ok(),
+            _ => None,
+        };
+
+        let task_type = match map.remove("task_type") {
+            Some(MemoryValue::String(s)) => {
+                serde_json::from_str(&format!("\"{}\"", s)).unwrap_or(TaskType::Feature)
+            }
+            _ => TaskType::Feature,
+        };
+
+        let status = match map.remove("status") {
+            Some(MemoryValue::String(s)) => {
+                serde_json::from_str(&format!("\"{}\"", s)).unwrap_or(TaskStatus::Todo)
+            }
+            _ => TaskStatus::Todo,
+        };
+
+        let priority = match map.remove("priority") {
+            Some(MemoryValue::String(s)) => {
+                serde_json::from_str(&format!("\"{}\"", s)).unwrap_or(Priority::Low)
+            }
+            _ => Priority::Low,
+        };
+
+        TaskProperties {
+            description,
+            created_at,
+            updated_at,
+            due_date,
+            task_type,
+            status,
+            priority,
+        }
+    }
+}
+
+impl From<TaskProperties> for HashMap<String, MemoryValue> {
+    fn from(props: TaskProperties) -> Self {
+        let mut map = HashMap::new();
+        map.insert(
+            "description".to_string(),
+            MemoryValue::String(props.description),
+        );
+        map.insert(
+            "created_at".to_string(),
+            MemoryValue::DateTime(props.created_at.into()),
+        );
+        map.insert(
+            "updated_at".to_string(),
+            MemoryValue::DateTime(props.updated_at.into()),
+        );
+        if let Some(due) = props.due_date {
+            map.insert("due_date".to_string(), MemoryValue::DateTime(due.into()));
+        }
+        map.insert(
+            "task_type".to_string(),
+            MemoryValue::String(format!("{:?}", props.task_type).to_lowercase()),
+        );
+        map.insert(
+            "status".to_string(),
+            MemoryValue::String(format!("{:?}", props.status).to_lowercase()),
+        );
+        map.insert(
+            "priority".to_string(),
+            MemoryValue::String(format!("{:?}", props.priority).to_lowercase()),
+        );
+        map
+    }
 }

--- a/crates/mm-core/src/operations/tasks/types.rs
+++ b/crates/mm-core/src/operations/tasks/types.rs
@@ -125,7 +125,7 @@ impl From<HashMap<String, MemoryValue>> for TaskProperties {
             Some(MemoryValue::String(s)) => {
                 serde_json::from_str(&format!("\"{}\"", s)).unwrap_or(Priority::Low)
             }
-            _ => Priority::Low,
+            _ => TaskProperties::default().priority,
         };
 
         TaskProperties {

--- a/crates/mm-core/src/operations/tasks/update_task.rs
+++ b/crates/mm-core/src/operations/tasks/update_task.rs
@@ -1,0 +1,70 @@
+use crate::error::{CoreError, CoreResult};
+use crate::ports::Ports;
+use crate::validate_name;
+use mm_memory::{EntityUpdate, MemoryRepository};
+use tracing::instrument;
+
+#[derive(Debug, Clone)]
+pub struct UpdateTaskCommand {
+    pub name: String,
+    pub update: EntityUpdate,
+}
+
+pub type UpdateTaskResult<E> = CoreResult<(), E>;
+
+#[instrument(skip(ports), fields(name = %command.name))]
+pub async fn update_task<R>(
+    ports: &Ports<R>,
+    command: UpdateTaskCommand,
+) -> UpdateTaskResult<R::Error>
+where
+    R: MemoryRepository + Send + Sync,
+    R::Error: std::error::Error + Send + Sync + 'static,
+{
+    validate_name!(command.name);
+
+    ports
+        .memory_service
+        .update_entity(&command.name, &command.update)
+        .await
+        .map_err(CoreError::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_update_task_success() {
+        let mut mock = MockMemoryRepository::new();
+        mock.expect_update_entity()
+            .withf(|n, _| n == "task:1")
+            .returning(|_, _| Ok(()));
+
+        let service = MemoryService::new(mock, MemoryConfig::default());
+        let ports = Ports::new(Arc::new(service));
+
+        let cmd = UpdateTaskCommand {
+            name: "task:1".into(),
+            update: EntityUpdate::default(),
+        };
+        let res = update_task(&ports, cmd).await;
+        assert!(res.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_update_task_empty_name() {
+        let mut mock = MockMemoryRepository::new();
+        mock.expect_update_entity().never();
+        let service = MemoryService::new(mock, MemoryConfig::default());
+        let ports = Ports::new(Arc::new(service));
+        let cmd = UpdateTaskCommand {
+            name: String::new(),
+            update: EntityUpdate::default(),
+        };
+        let res = update_task(&ports, cmd).await;
+        assert!(matches!(res, Err(CoreError::Validation(_))));
+    }
+}

--- a/crates/mm-memory/src/service.rs
+++ b/crates/mm-memory/src/service.rs
@@ -81,6 +81,11 @@ where
         Self { repository, config }
     }
 
+    /// Get a reference to the service configuration
+    pub fn memory_config(&self) -> &MemoryConfig {
+        &self.config
+    }
+
     /// Create multiple entities in a batch
     #[instrument(skip(self, entities), fields(entities_count = entities.len()))]
     pub async fn create_entities_typed<P>(

--- a/crates/mm-server/src/mcp/error.rs
+++ b/crates/mm-server/src/mcp/error.rs
@@ -54,6 +54,7 @@ where
                 .map(|(name, err)| format!("{}: {}", name, err))
                 .collect::<Vec<_>>()
                 .join("; "),
+            CoreError::MissingProject => "No project specified".to_string(),
         };
         Self::with_source(message, error)
     }


### PR DESCRIPTION
## Summary
- add getter `memory_config` for MemoryService
- implement typed task operations
- convert task properties to/from map and provide defaults
- cover task operations with tests
- introduce `MissingProject` error and split task operations into separate files
- remove unused test imports

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_685a39f8dfbc83279fcfcfc5dc9a1013