### PR TITLE
Implement MCP task tools and rename toolbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ cargo run -p mm-cli -- tools call tools/list '{}' --config config/default.toml,c
 View the JSON schema for a tool:
 
 ```bash
-cargo run -p mm-cli -- tools schema MemoryTools add_observations --config config/default.toml,config/local.toml
+cargo run -p mm-cli -- tools schema MMTools add_observations --config config/default.toml,config/local.toml
 ```
 
 

--- a/crates/mm-server/src/lib.rs
+++ b/crates/mm-server/src/lib.rs
@@ -33,7 +33,7 @@ use rust_mcp_sdk::{
 use tracing::{debug, error};
 
 pub mod mcp;
-use mcp::MemoryTools;
+use mcp::MMTools;
 mod resources;
 mod roots;
 
@@ -109,7 +109,7 @@ where
         Ok(ListToolsResult {
             meta: None,
             next_cursor: None,
-            tools: MemoryTools::tools(),
+            tools: MMTools::tools(),
         })
     }
 
@@ -160,27 +160,31 @@ where
         let tool_name = request.tool_name().to_string();
         debug!("Handling call tool request: {}", tool_name);
 
-        // Attempt to convert request parameters into MemoryTools enum
-        let tool_params = MemoryTools::try_from(request.params)
+        // Attempt to convert request parameters into MMTools enum
+        let tool_params = MMTools::try_from(request.params)
             .map_err(|_| CallToolError::unknown_tool(tool_name.clone()))?;
 
         // Match the tool variant and execute its corresponding logic
         let result = match tool_params {
-            MemoryTools::CreateEntitiesTool(create_entity_tool) => {
+            MMTools::CreateEntitiesTool(create_entity_tool) => {
                 create_entity_tool.call_tool(&self.ports).await?
             }
-            MemoryTools::CreateRelationshipsTool(tool) => tool.call_tool(&self.ports).await?,
-            MemoryTools::DeleteEntitiesTool(tool) => tool.call_tool(&self.ports).await?,
-            MemoryTools::DeleteRelationshipsTool(tool) => tool.call_tool(&self.ports).await?,
-            MemoryTools::FindEntitiesByLabelsTool(tool) => tool.call_tool(&self.ports).await?,
-            MemoryTools::FindRelationshipsTool(tool) => tool.call_tool(&self.ports).await?,
-            MemoryTools::GetEntityTool(get_entity_tool) => {
+            MMTools::CreateRelationshipsTool(tool) => tool.call_tool(&self.ports).await?,
+            MMTools::DeleteEntitiesTool(tool) => tool.call_tool(&self.ports).await?,
+            MMTools::DeleteRelationshipsTool(tool) => tool.call_tool(&self.ports).await?,
+            MMTools::FindEntitiesByLabelsTool(tool) => tool.call_tool(&self.ports).await?,
+            MMTools::FindRelationshipsTool(tool) => tool.call_tool(&self.ports).await?,
+            MMTools::CreateTaskTool(tool) => tool.call_tool(&self.ports).await?,
+            MMTools::GetTaskTool(tool) => tool.call_tool(&self.ports).await?,
+            MMTools::UpdateTaskTool(tool) => tool.call_tool(&self.ports).await?,
+            MMTools::DeleteTaskTool(tool) => tool.call_tool(&self.ports).await?,
+            MMTools::GetEntityTool(get_entity_tool) => {
                 get_entity_tool.call_tool(&self.ports).await?
             }
-            MemoryTools::GetProjectContextTool(tool) => tool.call_tool(&self.ports).await?,
-            MemoryTools::ListProjectsTool(tool) => tool.call_tool(&self.ports).await?,
-            MemoryTools::UpdateEntityTool(tool) => tool.call_tool(&self.ports).await?,
-            MemoryTools::UpdateRelationshipTool(tool) => tool.call_tool(&self.ports).await?,
+            MMTools::GetProjectContextTool(tool) => tool.call_tool(&self.ports).await?,
+            MMTools::ListProjectsTool(tool) => tool.call_tool(&self.ports).await?,
+            MMTools::UpdateEntityTool(tool) => tool.call_tool(&self.ports).await?,
+            MMTools::UpdateRelationshipTool(tool) => tool.call_tool(&self.ports).await?,
         };
         Ok(result)
     }
@@ -312,8 +316,8 @@ pub async fn run_tools<P: AsRef<Path>>(command: ToolsCommand, config_paths: &[P]
 
     match command {
         ToolsCommand::List => {
-            println!("MemoryTools:");
-            for tool in MemoryTools::tools() {
+            println!("MMTools:");
+            for tool in MMTools::tools() {
                 let desc = tool.description.unwrap_or_default();
                 println!("  {} - {}", tool.name, desc);
             }
@@ -326,7 +330,7 @@ pub async fn run_tools<P: AsRef<Path>>(command: ToolsCommand, config_paths: &[P]
                 let result = ListToolsResult {
                     meta: None,
                     next_cursor: None,
-                    tools: MemoryTools::tools(),
+                    tools: MMTools::tools(),
                 };
                 println!("{}", serde_json::to_string_pretty(&result)?);
             }
@@ -349,26 +353,30 @@ pub async fn run_tools<P: AsRef<Path>>(command: ToolsCommand, config_paths: &[P]
                     arguments: Some(map),
                 };
                 let tool =
-                    MemoryTools::try_from(params).map_err(|e| anyhow::anyhow!(format!("{e:?}")))?;
+                    MMTools::try_from(params).map_err(|e| anyhow::anyhow!(format!("{e:?}")))?;
                 let result = match tool {
-                    MemoryTools::CreateEntitiesTool(t) => t.call_tool(&ports).await,
-                    MemoryTools::CreateRelationshipsTool(t) => t.call_tool(&ports).await,
-                    MemoryTools::DeleteEntitiesTool(t) => t.call_tool(&ports).await,
-                    MemoryTools::DeleteRelationshipsTool(t) => t.call_tool(&ports).await,
-                    MemoryTools::FindEntitiesByLabelsTool(t) => t.call_tool(&ports).await,
-                    MemoryTools::FindRelationshipsTool(t) => t.call_tool(&ports).await,
-                    MemoryTools::GetEntityTool(t) => t.call_tool(&ports).await,
-                    MemoryTools::GetProjectContextTool(t) => t.call_tool(&ports).await,
-                    MemoryTools::ListProjectsTool(t) => t.call_tool(&ports).await,
-                    MemoryTools::UpdateEntityTool(t) => t.call_tool(&ports).await,
-                    MemoryTools::UpdateRelationshipTool(t) => t.call_tool(&ports).await,
+                    MMTools::CreateEntitiesTool(t) => t.call_tool(&ports).await,
+                    MMTools::CreateRelationshipsTool(t) => t.call_tool(&ports).await,
+                    MMTools::DeleteEntitiesTool(t) => t.call_tool(&ports).await,
+                    MMTools::DeleteRelationshipsTool(t) => t.call_tool(&ports).await,
+                    MMTools::FindEntitiesByLabelsTool(t) => t.call_tool(&ports).await,
+                    MMTools::FindRelationshipsTool(t) => t.call_tool(&ports).await,
+                    MMTools::CreateTaskTool(t) => t.call_tool(&ports).await,
+                    MMTools::GetTaskTool(t) => t.call_tool(&ports).await,
+                    MMTools::UpdateTaskTool(t) => t.call_tool(&ports).await,
+                    MMTools::DeleteTaskTool(t) => t.call_tool(&ports).await,
+                    MMTools::GetEntityTool(t) => t.call_tool(&ports).await,
+                    MMTools::GetProjectContextTool(t) => t.call_tool(&ports).await,
+                    MMTools::ListProjectsTool(t) => t.call_tool(&ports).await,
+                    MMTools::UpdateEntityTool(t) => t.call_tool(&ports).await,
+                    MMTools::UpdateRelationshipTool(t) => t.call_tool(&ports).await,
                 }
                 .map_err(|e| anyhow::anyhow!(format!("{e:?}")))?;
                 println!("{}", serde_json::to_string_pretty(&result)?);
             }
         },
         ToolsCommand::Schema { toolbox, tool_name } => {
-            if toolbox != "MemoryTools" {
+            if toolbox != "MMTools" {
                 anyhow::bail!("Unknown toolbox: {}", toolbox);
             }
             let schema = match tool_name.as_str() {
@@ -378,6 +386,10 @@ pub async fn run_tools<P: AsRef<Path>>(command: ToolsCommand, config_paths: &[P]
                 "delete_relationships" => mcp::DeleteRelationshipsTool::json_schema(),
                 "find_entities_by_labels" => mcp::FindEntitiesByLabelsTool::json_schema(),
                 "find_relationships" => mcp::FindRelationshipsTool::json_schema(),
+                "create_task" => mcp::CreateTaskTool::json_schema(),
+                "get_task" => mcp::GetTaskTool::json_schema(),
+                "update_task" => mcp::UpdateTaskTool::json_schema(),
+                "delete_task" => mcp::DeleteTaskTool::json_schema(),
                 "get_entity" => mcp::GetEntityTool::json_schema(),
                 "get_project_context" => mcp::GetProjectContextTool::json_schema(),
                 "list_projects" => mcp::ListProjectsTool::json_schema(),

--- a/crates/mm-server/src/mcp/create_task.rs
+++ b/crates/mm-server/src/mcp/create_task.rs
@@ -1,0 +1,88 @@
+use mm_core::operations::memory::{CreateTaskCommand, TaskProperties, create_task};
+use mm_memory::MemoryEntity;
+use mm_utils::IntoJsonSchema;
+use rust_mcp_sdk::macros::mcp_tool;
+use serde::{Deserialize, Serialize};
+
+#[mcp_tool(
+    name = "create_task",
+    description = "Create a task and associate it with a project"
+)]
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct CreateTaskTool {
+    /// Unique task name
+    pub task_name: String,
+    /// Labels for the task
+    pub labels: Vec<String>,
+    /// Observations describing the task
+    #[serde(default)]
+    pub observations: Vec<String>,
+    /// Task properties
+    #[serde(default)]
+    pub properties: Option<TaskProperties>,
+    /// Project to associate with
+    pub project_name: Option<String>,
+}
+
+impl CreateTaskTool {
+    generate_call_tool!(
+        self,
+        CreateTaskCommand {
+            task => MemoryEntity::<TaskProperties> {
+                name: self.task_name.clone(),
+                labels: self.labels.clone(),
+                observations: self.observations.clone(),
+                properties: self.properties.clone().unwrap_or_default(),
+                relationships: Vec::new(),
+            },
+            project_name
+        },
+        create_task,
+        |command, _result| {
+            Ok(rust_mcp_sdk::schema::CallToolResult::text_content(
+                command.task.name,
+                None,
+            ))
+        }
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mm_core::Ports;
+    use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_call_tool_success() {
+        let mut mock = MockMemoryRepository::new();
+        mock.expect_create_entities()
+            .withf(|ents| ents.len() == 1 && ents[0].name == "task:1")
+            .returning(|_| Ok(()));
+        mock.expect_create_relationships()
+            .withf(|rels| rels.len() == 1 && rels[0].from == "proj" && rels[0].to == "task:1")
+            .returning(|_| Ok(()));
+
+        let service = MemoryService::new(
+            mock,
+            MemoryConfig {
+                default_project: Some("proj".into()),
+                ..MemoryConfig::default()
+            },
+        );
+        let ports = Ports::new(Arc::new(service));
+
+        let tool = CreateTaskTool {
+            task_name: "task:1".into(),
+            labels: vec!["Task".into()],
+            observations: vec![],
+            properties: None,
+            project_name: None,
+        };
+
+        let result = tool.call_tool(&ports).await.unwrap();
+        let text = result.content[0].as_text_content().unwrap().text.clone();
+        assert_eq!(text, "task:1");
+    }
+}

--- a/crates/mm-server/src/mcp/delete_task.rs
+++ b/crates/mm-server/src/mcp/delete_task.rs
@@ -1,0 +1,52 @@
+use mm_core::operations::memory::{DeleteTaskCommand, delete_task};
+use mm_utils::IntoJsonSchema;
+use rust_mcp_sdk::macros::mcp_tool;
+use serde::{Deserialize, Serialize};
+
+#[mcp_tool(name = "delete_task", description = "Delete a task")]
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct DeleteTaskTool {
+    /// Task name
+    pub task_name: String,
+    /// Optional project name (unused)
+    pub project_name: Option<String>,
+}
+
+impl DeleteTaskTool {
+    generate_call_tool!(
+        self,
+        DeleteTaskCommand { name => self.task_name.clone() },
+        delete_task,
+        |command, _res| {
+            Ok(rust_mcp_sdk::schema::CallToolResult::text_content(command.name, None))
+        }
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mm_core::Ports;
+    use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_call_tool_success() {
+        let mut mock = MockMemoryRepository::new();
+        mock.expect_delete_entities()
+            .withf(|names| names.len() == 1 && names[0] == "task:1")
+            .returning(|_| Ok(()));
+
+        let service = MemoryService::new(mock, MemoryConfig::default());
+        let ports = Ports::new(Arc::new(service));
+
+        let tool = DeleteTaskTool {
+            task_name: "task:1".into(),
+            project_name: None,
+        };
+
+        let result = tool.call_tool(&ports).await.unwrap();
+        let text = result.content[0].as_text_content().unwrap().text.clone();
+        assert_eq!(text, "task:1");
+    }
+}

--- a/crates/mm-server/src/mcp/get_task.rs
+++ b/crates/mm-server/src/mcp/get_task.rs
@@ -1,0 +1,68 @@
+use mm_core::operations::memory::{GetTaskCommand, get_task};
+use mm_utils::IntoJsonSchema;
+use rust_mcp_sdk::macros::mcp_tool;
+use serde::{Deserialize, Serialize};
+
+#[mcp_tool(name = "get_task", description = "Retrieve a task by name")]
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct GetTaskTool {
+    /// Task name
+    pub task_name: String,
+    /// Optional project name (unused)
+    pub project_name: Option<String>,
+}
+
+impl GetTaskTool {
+    generate_call_tool!(
+        self,
+        GetTaskCommand { name => self.task_name.clone() },
+        get_task,
+        |command, result| {
+            match result {
+                Some(entity) => serde_json::to_value(entity)
+                    .map(|json| rust_mcp_sdk::schema::CallToolResult::text_content(json.to_string(), None))
+                    .map_err(|e| rust_mcp_sdk::schema::schema_utils::CallToolError::new(crate::mcp::error::ToolError::from(e))),
+                None => Ok(rust_mcp_sdk::schema::CallToolResult::text_content(
+                    format!("Task '{}' not found", command.name),
+                    None,
+                )),
+            }
+        }
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mm_core::Ports;
+    use mm_memory::{MemoryConfig, MemoryEntity, MemoryService, MockMemoryRepository};
+    use mockall::predicate::*;
+    use serde_json::Value;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_call_tool_success() {
+        let entity = MemoryEntity {
+            name: "task:1".into(),
+            labels: vec!["Task".into()],
+            ..Default::default()
+        };
+        let mut mock = MockMemoryRepository::new();
+        mock.expect_find_entity_by_name()
+            .with(eq("task:1"))
+            .returning(move |_| Ok(Some(entity.clone())));
+
+        let service = MemoryService::new(mock, MemoryConfig::default());
+        let ports = Ports::new(Arc::new(service));
+
+        let tool = GetTaskTool {
+            task_name: "task:1".into(),
+            project_name: None,
+        };
+
+        let result = tool.call_tool(&ports).await.unwrap();
+        let text = result.content[0].as_text_content().unwrap().text.clone();
+        let value: Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(value["name"], "task:1");
+    }
+}

--- a/crates/mm-server/src/mcp/mod.rs
+++ b/crates/mm-server/src/mcp/mod.rs
@@ -2,34 +2,42 @@
 mod macros;
 pub mod create_entities;
 pub mod create_relationships;
+pub mod create_task;
 pub mod delete_entities;
 pub mod delete_relationships;
+pub mod delete_task;
 pub mod error;
 pub mod find_entities_by_labels;
 pub mod find_relationships;
 pub mod get_entity;
 pub mod get_project_context;
+pub mod get_task;
 pub mod list_projects;
 pub mod update_entity;
 pub mod update_relationship;
+pub mod update_task;
 
 use rust_mcp_sdk::tool_box;
 
 pub use create_entities::CreateEntitiesTool;
 pub use create_relationships::CreateRelationshipsTool;
+pub use create_task::CreateTaskTool;
 pub use delete_entities::DeleteEntitiesTool;
 pub use delete_relationships::DeleteRelationshipsTool;
+pub use delete_task::DeleteTaskTool;
 pub use find_entities_by_labels::FindEntitiesByLabelsTool;
 pub use find_relationships::FindRelationshipsTool;
 pub use get_entity::GetEntityTool;
 pub use get_project_context::GetProjectContextTool;
+pub use get_task::GetTaskTool;
 pub use list_projects::ListProjectsTool;
 pub use update_entity::UpdateEntityTool;
 pub use update_relationship::UpdateRelationshipTool;
+pub use update_task::UpdateTaskTool;
 
 // Generate an enum with all tools
 tool_box!(
-    MemoryTools,
+    MMTools,
     [
         CreateEntitiesTool,
         CreateRelationshipsTool,
@@ -37,6 +45,10 @@ tool_box!(
         DeleteRelationshipsTool,
         FindEntitiesByLabelsTool,
         FindRelationshipsTool,
+        CreateTaskTool,
+        GetTaskTool,
+        UpdateTaskTool,
+        DeleteTaskTool,
         GetEntityTool,
         GetProjectContextTool,
         ListProjectsTool,

--- a/crates/mm-server/src/mcp/update_task.rs
+++ b/crates/mm-server/src/mcp/update_task.rs
@@ -1,0 +1,76 @@
+use mm_core::operations::memory::{TaskProperties, UpdateTaskCommand, update_task};
+use mm_memory::{EntityUpdate, ObservationsUpdate, PropertiesUpdate};
+use mm_utils::IntoJsonSchema;
+use rust_mcp_sdk::macros::mcp_tool;
+use serde::{Deserialize, Serialize};
+
+#[mcp_tool(
+    name = "update_task",
+    description = "Update a task's observations or properties"
+)]
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct UpdateTaskTool {
+    /// Task name
+    pub task_name: String,
+    /// Optional project name (unused)
+    pub project_name: Option<String>,
+    /// Replace observations
+    #[serde(default)]
+    pub observations: Option<Vec<String>>,
+    /// Replace properties
+    #[serde(default)]
+    pub properties: Option<TaskProperties>,
+}
+
+impl UpdateTaskTool {
+    generate_call_tool!(
+        self,
+        UpdateTaskCommand {
+            name => self.task_name.clone(),
+            update => {
+                let mut update = EntityUpdate::default();
+                if let Some(obs) = self.observations.clone() {
+                    update.observations = Some(ObservationsUpdate { add: None, remove: None, set: Some(obs) });
+                }
+                if let Some(props) = self.properties.clone() {
+                    update.properties = Some(PropertiesUpdate { add: None, remove: None, set: Some(props.into()) });
+                }
+                update
+            }
+        },
+        update_task,
+        |command, _res| {
+            Ok(rust_mcp_sdk::schema::CallToolResult::text_content(command.name, None))
+        }
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mm_core::Ports;
+    use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_call_tool_success() {
+        let mut mock = MockMemoryRepository::new();
+        mock.expect_update_entity()
+            .withf(|n, _| n == "task:1")
+            .returning(|_, _| Ok(()));
+
+        let service = MemoryService::new(mock, MemoryConfig::default());
+        let ports = Ports::new(Arc::new(service));
+
+        let tool = UpdateTaskTool {
+            task_name: "task:1".into(),
+            project_name: None,
+            observations: Some(vec!["done".into()]),
+            properties: None,
+        };
+
+        let result = tool.call_tool(&ports).await.unwrap();
+        let text = result.content[0].as_text_content().unwrap().text.clone();
+        assert_eq!(text, "task:1");
+    }
+}


### PR DESCRIPTION
## Summary
- add new task CRUD tools to `mm-server`
- rename `MemoryTools` enum to `MMTools`
- update CLI to use new toolbox name
- document updated toolbox usage in README

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_685ae25a26c083279ddba5be4d6e22dc