### PR TITLE
Add basic Git support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,6 +1420,7 @@ dependencies = [
  "arbtest",
  "async-trait",
  "chrono",
+ "mm-git",
  "mm-memory",
  "mm-utils",
  "mockall",
@@ -1429,6 +1430,18 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "mm-git"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "mockall",
+ "schemars",
+ "serde",
+ "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "crates/mm-cli",
     "crates/mm-core",
+    "crates/mm-git",
     "crates/mm-memory",
     "crates/mm-memory-neo4j",
     "crates/mm-server",

--- a/crates/mm-core/Cargo.toml
+++ b/crates/mm-core/Cargo.toml
@@ -6,6 +6,7 @@ license = "MPL-2.0"
 
 [dependencies]
 mm-memory = { path = "../mm-memory" }
+mm-git = { path = "../mm-git" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -18,6 +19,7 @@ chrono = { workspace = true }
 mockall = { workspace = true }
 tokio = { workspace = true, features = ["full", "test-util"] }
 mm-memory = { path = "../mm-memory", features = ["mock"] }
+mm-git = { path = "../mm-git", features = ["mock"] }
 arbitrary = { workspace = true }
 arbtest = { workspace = true }
 mm-utils = { path = "../mm-utils" }

--- a/crates/mm-core/Cargo.toml
+++ b/crates/mm-core/Cargo.toml
@@ -15,6 +15,9 @@ async-trait = { workspace = true }
 schemars = { workspace = true }
 chrono = { workspace = true }
 
+[features]
+mock = ["mm-memory/mock", "mm-git/mock"]
+
 [dev-dependencies]
 mockall = { workspace = true }
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/mm-core/src/error.rs
+++ b/crates/mm-core/src/error.rs
@@ -3,12 +3,16 @@ use thiserror::Error;
 
 /// Error type for mm-core
 #[derive(Error, Debug)]
-pub enum CoreError<E>
+pub enum CoreError<ME, GE>
 where
-    E: StdError + Send + Sync + 'static,
+    ME: StdError + Send + Sync + 'static,
+    GE: StdError + Send + Sync + 'static,
 {
     #[error("Memory error")]
-    Memory(#[from] mm_memory::MemoryError<E>),
+    Memory(#[from] mm_memory::MemoryError<ME>),
+
+    #[error("Git error")]
+    Git(#[from] mm_git::GitError<GE>),
 
     #[error("Serialization error: {0}")]
     Serialization(#[from] serde_json::Error),
@@ -26,4 +30,4 @@ where
 }
 
 /// Result type for mm-core
-pub type CoreResult<T, E> = std::result::Result<T, CoreError<E>>;
+pub type CoreResult<T, E> = std::result::Result<T, CoreError<E, E>>;

--- a/crates/mm-core/src/lib.rs
+++ b/crates/mm-core/src/lib.rs
@@ -16,4 +16,5 @@ pub use ports::Ports;
 pub use root::{Root, RootCollection};
 
 // Re-export the mm-memory crate for easy access to memory types and services
+pub use mm_git;
 pub use mm_memory;

--- a/crates/mm-core/src/operations/git/mod.rs
+++ b/crates/mm-core/src/operations/git/mod.rs
@@ -1,0 +1,3 @@
+pub mod status;
+
+pub use status::{GetGitStatusCommand, GetGitStatusResult, get_git_status};

--- a/crates/mm-core/src/operations/git/status.rs
+++ b/crates/mm-core/src/operations/git/status.rs
@@ -1,0 +1,63 @@
+use std::path::PathBuf;
+
+use crate::error::{CoreError, CoreResult};
+use crate::ports::Ports;
+use mm_git::{GitRepository, GitStatus};
+use mm_memory::MemoryRepository;
+
+#[derive(Debug, Clone)]
+pub struct GetGitStatusCommand {
+    pub path: PathBuf,
+}
+
+pub type GetGitStatusResult<E> = CoreResult<GitStatus, E>;
+
+pub async fn get_git_status<MR, GR>(
+    ports: &Ports<MR, GR>,
+    command: GetGitStatusCommand,
+) -> GetGitStatusResult<GR::Error>
+where
+    MR: MemoryRepository + Send + Sync,
+    GR: GitRepository + Send + Sync,
+    GR::Error: std::error::Error + Send + Sync + 'static,
+{
+    let path = &command.path;
+
+    ports
+        .git_service
+        .get_status(path)
+        .await
+        .map_err(CoreError::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mm_git::GitService;
+    use mm_git::repository::MockGitRepository;
+    use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_get_git_status_success() {
+        let mut mock = MockGitRepository::new();
+        mock.expect_get_status().returning(|_| {
+            Ok(GitStatus {
+                branch: "main".to_string(),
+            })
+        });
+        let git_service = Arc::new(GitService::new(mock));
+        let memory_service = Arc::new(MemoryService::new(
+            MockMemoryRepository::new(),
+            MemoryConfig::default(),
+        ));
+        let ports = Ports::new(memory_service, git_service.clone());
+
+        let command = GetGitStatusCommand {
+            path: PathBuf::from("/tmp"),
+        };
+
+        let status = get_git_status(&ports, command).await.unwrap();
+        assert_eq!(status.branch, "main");
+    }
+}

--- a/crates/mm-core/src/operations/git/status.rs
+++ b/crates/mm-core/src/operations/git/status.rs
@@ -47,11 +47,10 @@ mod tests {
             })
         });
         let git_service = Arc::new(GitService::new(mock));
-        let memory_service = Arc::new(MemoryService::new(
-            MockMemoryRepository::new(),
-            MemoryConfig::default(),
-        ));
-        let ports = Ports::new(memory_service, git_service.clone());
+        let ports = Ports {
+            git_service: git_service.clone(),
+            ..Ports::new_noop()
+        };
 
         let command = GetGitStatusCommand {
             path: PathBuf::from("/tmp"),

--- a/crates/mm-core/src/operations/memory/create_entity.rs
+++ b/crates/mm-core/src/operations/memory/create_entity.rs
@@ -1,5 +1,6 @@
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
+use mm_git::GitRepository;
 use mm_memory::MemoryEntity;
 use mm_memory::MemoryRepository;
 use tracing::instrument;
@@ -24,13 +25,14 @@ pub type CreateEntitiesResult<E> = CoreResult<(), E>;
 ///
 /// Ok(()) if the entity was created successfully, or an error
 #[instrument(skip(ports), fields(entities_count = command.entities.len()))]
-pub async fn create_entities<R>(
-    ports: &Ports<R>,
+pub async fn create_entities<MR, GR>(
+    ports: &Ports<MR, GR>,
     command: CreateEntitiesCommand,
-) -> CreateEntitiesResult<R::Error>
+) -> CreateEntitiesResult<MR::Error>
 where
-    R: MemoryRepository + Send + Sync,
-    R::Error: std::error::Error + Send + Sync + 'static,
+    MR: MemoryRepository + Send + Sync,
+    MR::Error: std::error::Error + Send + Sync + 'static,
+    GR: GitRepository + Send + Sync,
 {
     let errors = ports
         .memory_service
@@ -48,6 +50,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mm_git::GitService;
     use mm_memory::ValidationErrorKind;
     use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
     use std::sync::Arc;
@@ -69,7 +72,7 @@ mod tests {
                 ..MemoryConfig::default()
             },
         );
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
 
         let command = CreateEntitiesCommand {
             entities: vec![MemoryEntity {
@@ -97,7 +100,7 @@ mod tests {
                 ..MemoryConfig::default()
             },
         );
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
 
         let command = CreateEntitiesCommand {
             entities: vec![MemoryEntity {
@@ -133,7 +136,7 @@ mod tests {
                 ..MemoryConfig::default()
             },
         );
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
 
         let command = CreateEntitiesCommand {
             entities: vec![MemoryEntity {
@@ -162,7 +165,7 @@ mod tests {
                 ..MemoryConfig::default()
             },
         );
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
 
         let command = CreateEntitiesCommand {
             entities: vec![

--- a/crates/mm-core/src/operations/memory/create_entity.rs
+++ b/crates/mm-core/src/operations/memory/create_entity.rs
@@ -72,7 +72,10 @@ mod tests {
                 ..MemoryConfig::default()
             },
         );
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
 
         let command = CreateEntitiesCommand {
             entities: vec![MemoryEntity {
@@ -100,7 +103,10 @@ mod tests {
                 ..MemoryConfig::default()
             },
         );
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
 
         let command = CreateEntitiesCommand {
             entities: vec![MemoryEntity {
@@ -136,7 +142,10 @@ mod tests {
                 ..MemoryConfig::default()
             },
         );
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
 
         let command = CreateEntitiesCommand {
             entities: vec![MemoryEntity {
@@ -165,7 +174,10 @@ mod tests {
                 ..MemoryConfig::default()
             },
         );
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
 
         let command = CreateEntitiesCommand {
             entities: vec![

--- a/crates/mm-core/src/operations/memory/create_relationship.rs
+++ b/crates/mm-core/src/operations/memory/create_relationship.rs
@@ -51,7 +51,10 @@ mod tests {
             .returning(|_| Ok(()));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
 
         let command = CreateRelationshipsCommand {
             relationships: vec![MemoryRelationship {
@@ -71,7 +74,10 @@ mod tests {
         let mut mock = MockMemoryRepository::new();
         mock.expect_create_relationships().never();
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
 
         let command = CreateRelationshipsCommand {
             relationships: vec![MemoryRelationship {
@@ -94,7 +100,10 @@ mod tests {
         let mut mock = MockMemoryRepository::new();
         mock.expect_create_relationships().never();
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
 
         let command = CreateRelationshipsCommand {
             relationships: vec![MemoryRelationship {
@@ -117,7 +126,10 @@ mod tests {
         let mut mock = MockMemoryRepository::new();
         mock.expect_create_relationships().never();
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
 
         let command = CreateRelationshipsCommand {
             relationships: vec![MemoryRelationship {
@@ -141,7 +153,10 @@ mod tests {
         mock.expect_create_relationships().never();
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
 
         let command = CreateRelationshipsCommand {
             relationships: vec![

--- a/crates/mm-core/src/operations/memory/create_relationship.rs
+++ b/crates/mm-core/src/operations/memory/create_relationship.rs
@@ -1,5 +1,6 @@
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
+use mm_git::GitRepository;
 use mm_memory::{MemoryRelationship, MemoryRepository};
 use tracing::instrument;
 
@@ -11,13 +12,14 @@ pub struct CreateRelationshipsCommand {
 pub type CreateRelationshipsResult<E> = CoreResult<(), E>;
 
 #[instrument(skip(ports), fields(relationships_count = command.relationships.len()))]
-pub async fn create_relationships<R>(
-    ports: &Ports<R>,
+pub async fn create_relationships<MR, GR>(
+    ports: &Ports<MR, GR>,
     command: CreateRelationshipsCommand,
-) -> CreateRelationshipsResult<R::Error>
+) -> CreateRelationshipsResult<MR::Error>
 where
-    R: MemoryRepository + Send + Sync,
-    R::Error: std::error::Error + Send + Sync + 'static,
+    MR: MemoryRepository + Send + Sync,
+    MR::Error: std::error::Error + Send + Sync + 'static,
+    GR: GitRepository + Send + Sync,
 {
     let errors = ports
         .memory_service
@@ -35,6 +37,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mm_git::GitService;
     use mm_memory::ValidationErrorKind;
     use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
     use std::collections::HashMap;
@@ -48,7 +51,7 @@ mod tests {
             .returning(|_| Ok(()));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
 
         let command = CreateRelationshipsCommand {
             relationships: vec![MemoryRelationship {
@@ -68,7 +71,7 @@ mod tests {
         let mut mock = MockMemoryRepository::new();
         mock.expect_create_relationships().never();
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
 
         let command = CreateRelationshipsCommand {
             relationships: vec![MemoryRelationship {
@@ -91,7 +94,7 @@ mod tests {
         let mut mock = MockMemoryRepository::new();
         mock.expect_create_relationships().never();
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
 
         let command = CreateRelationshipsCommand {
             relationships: vec![MemoryRelationship {
@@ -114,7 +117,7 @@ mod tests {
         let mut mock = MockMemoryRepository::new();
         mock.expect_create_relationships().never();
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
 
         let command = CreateRelationshipsCommand {
             relationships: vec![MemoryRelationship {
@@ -138,7 +141,7 @@ mod tests {
         mock.expect_create_relationships().never();
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
 
         let command = CreateRelationshipsCommand {
             relationships: vec![

--- a/crates/mm-core/src/operations/memory/delete_entities.rs
+++ b/crates/mm-core/src/operations/memory/delete_entities.rs
@@ -1,5 +1,6 @@
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
+use mm_git::GitRepository;
 use mm_memory::MemoryRepository;
 use tracing::instrument;
 
@@ -11,13 +12,14 @@ pub struct DeleteEntitiesCommand {
 pub type DeleteEntitiesResult<E> = CoreResult<(), E>;
 
 #[instrument(skip(ports), fields(names_count = command.names.len()))]
-pub async fn delete_entities<R>(
-    ports: &Ports<R>,
+pub async fn delete_entities<MR, GR>(
+    ports: &Ports<MR, GR>,
     command: DeleteEntitiesCommand,
-) -> DeleteEntitiesResult<R::Error>
+) -> DeleteEntitiesResult<MR::Error>
 where
-    R: MemoryRepository + Send + Sync,
-    R::Error: std::error::Error + Send + Sync + 'static,
+    MR: MemoryRepository + Send + Sync,
+    MR::Error: std::error::Error + Send + Sync + 'static,
+    GR: GitRepository + Send + Sync,
 {
     let errors = ports
         .memory_service

--- a/crates/mm-core/src/operations/memory/delete_relationships.rs
+++ b/crates/mm-core/src/operations/memory/delete_relationships.rs
@@ -1,5 +1,6 @@
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
+use mm_git::GitRepository;
 use mm_memory::{MemoryRepository, relationship::RelationshipRef};
 use tracing::instrument;
 
@@ -11,13 +12,14 @@ pub struct DeleteRelationshipsCommand {
 pub type DeleteRelationshipsResult<E> = CoreResult<(), E>;
 
 #[instrument(skip(ports), fields(rel_count = command.relationships.len()))]
-pub async fn delete_relationships<R>(
-    ports: &Ports<R>,
+pub async fn delete_relationships<MR, GR>(
+    ports: &Ports<MR, GR>,
     command: DeleteRelationshipsCommand,
-) -> DeleteRelationshipsResult<R::Error>
+) -> DeleteRelationshipsResult<MR::Error>
 where
-    R: MemoryRepository + Send + Sync,
-    R::Error: std::error::Error + Send + Sync + 'static,
+    MR: MemoryRepository + Send + Sync,
+    MR::Error: std::error::Error + Send + Sync + 'static,
+    GR: GitRepository + Send + Sync,
 {
     let errors = ports
         .memory_service

--- a/crates/mm-core/src/operations/memory/find_entities_by_labels.rs
+++ b/crates/mm-core/src/operations/memory/find_entities_by_labels.rs
@@ -1,5 +1,6 @@
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
+use mm_git::GitRepository;
 use mm_memory::{LabelMatchMode, MemoryEntity, MemoryRepository};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -20,13 +21,14 @@ pub struct FindEntitiesByLabelsResult {
 pub type FindEntitiesByLabelsResultType<E> = CoreResult<FindEntitiesByLabelsResult, E>;
 
 #[instrument(skip(ports), fields(label_count = command.labels.len()))]
-pub async fn find_entities_by_labels<R>(
-    ports: &Ports<R>,
+pub async fn find_entities_by_labels<MR, GR>(
+    ports: &Ports<MR, GR>,
     command: FindEntitiesByLabelsCommand,
-) -> FindEntitiesByLabelsResultType<R::Error>
+) -> FindEntitiesByLabelsResultType<MR::Error>
 where
-    R: MemoryRepository + Send + Sync,
-    R::Error: std::error::Error + Send + Sync + 'static,
+    MR: MemoryRepository + Send + Sync,
+    MR::Error: std::error::Error + Send + Sync + 'static,
+    GR: GitRepository + Send + Sync,
 {
     let entities = ports
         .memory_service

--- a/crates/mm-core/src/operations/memory/find_relationships.rs
+++ b/crates/mm-core/src/operations/memory/find_relationships.rs
@@ -1,5 +1,6 @@
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
+use mm_git::GitRepository;
 use mm_memory::{MemoryRelationship, MemoryRepository};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -20,13 +21,14 @@ pub struct FindRelationshipsResult {
 pub type FindRelationshipsResultType<E> = CoreResult<FindRelationshipsResult, E>;
 
 #[instrument(skip(ports))]
-pub async fn find_relationships<R>(
-    ports: &Ports<R>,
+pub async fn find_relationships<MR, GR>(
+    ports: &Ports<MR, GR>,
     command: FindRelationshipsCommand,
-) -> FindRelationshipsResultType<R::Error>
+) -> FindRelationshipsResultType<MR::Error>
 where
-    R: MemoryRepository + Send + Sync,
-    R::Error: std::error::Error + Send + Sync + 'static,
+    MR: MemoryRepository + Send + Sync,
+    MR::Error: std::error::Error + Send + Sync + 'static,
+    GR: GitRepository + Send + Sync,
 {
     let rels = ports
         .memory_service

--- a/crates/mm-core/src/operations/memory/get_project_context.rs
+++ b/crates/mm-core/src/operations/memory/get_project_context.rs
@@ -219,7 +219,10 @@ mod tests {
             .returning(move |_, _, _, _| Ok(vec![project_entity2.clone(), related_entity.clone()]));
 
         let service = MemoryService::new(mock_repo, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
 
         let command = GetProjectContextCommand {
             filter: ProjectFilter::Name("andoriyu:project:middle_manager".to_string()),
@@ -311,7 +314,10 @@ mod tests {
             .returning(move |_, _, _, _| Ok(vec![project_entity2.clone(), related_entity.clone()]));
 
         let service = MemoryService::new(mock_repo, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
 
         let command = GetProjectContextCommand {
             filter: ProjectFilter::Repository("andoriyu/middle-manager".to_string()),
@@ -338,7 +344,10 @@ mod tests {
             .returning(|_| Ok(None));
 
         let service = MemoryService::new(mock_repo, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
 
         let command = GetProjectContextCommand {
             filter: ProjectFilter::Name("nonexistent:project".to_string()),
@@ -375,7 +384,10 @@ mod tests {
             .returning(move |_| Ok(Some(entity.clone())));
 
         let service = MemoryService::new(mock_repo, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
 
         let command = GetProjectContextCommand {
             filter: ProjectFilter::Name("tech:language:rust".to_string()),
@@ -407,7 +419,10 @@ mod tests {
             .returning(|_, _, _| Ok(vec![]));
 
         let service = MemoryService::new(mock_repo, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
 
         let command = GetProjectContextCommand {
             filter: ProjectFilter::Repository("nonexistent/repo".to_string()),
@@ -459,7 +474,10 @@ mod tests {
             .returning(|_, _, _, _| Ok(vec![]));
 
         let service = MemoryService::new(mock_repo, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
 
         let command = GetProjectContextCommand {
             filter: ProjectFilter::Repository("andoriyu/no-project".to_string()),

--- a/crates/mm-core/src/operations/memory/list_projects.rs
+++ b/crates/mm-core/src/operations/memory/list_projects.rs
@@ -91,7 +91,10 @@ mod tests {
             .returning(move |_, _, _| Ok(vec![project1.clone(), project2.clone()]));
 
         let service = MemoryService::new(mock_repo, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
 
         let command = ListProjectsCommand { name_filter: None };
 
@@ -134,7 +137,10 @@ mod tests {
             .returning(move |_, _, _| Ok(vec![project1.clone(), project2.clone()]));
 
         let service = MemoryService::new(mock_repo, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
 
         let command = ListProjectsCommand {
             name_filter: Some("flakes".to_string()),
@@ -162,7 +168,10 @@ mod tests {
             .returning(move |_, _, _| Ok(vec![]));
 
         let service = MemoryService::new(mock_repo, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
 
         let command = ListProjectsCommand { name_filter: None };
 

--- a/crates/mm-core/src/operations/memory/tasks/create_task.rs
+++ b/crates/mm-core/src/operations/memory/tasks/create_task.rs
@@ -98,7 +98,10 @@ mod tests {
                 ..MemoryConfig::default()
             },
         );
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
 
         let cmd = CreateTaskCommand {
             task: MemoryEntity::<TaskProperties> {
@@ -120,7 +123,10 @@ mod tests {
         mock.expect_create_relationships().never();
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
 
         let cmd = CreateTaskCommand {
             task: MemoryEntity::<TaskProperties> {
@@ -148,7 +154,10 @@ mod tests {
                 ..MemoryConfig::default()
             },
         );
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
 
         let cmd = CreateTaskCommand {
             task: MemoryEntity::<TaskProperties> {

--- a/crates/mm-core/src/operations/memory/tasks/delete_task.rs
+++ b/crates/mm-core/src/operations/memory/tasks/delete_task.rs
@@ -51,7 +51,10 @@ mod tests {
             .withf(|n| n.len() == 1 && n[0] == "task:1")
             .returning(|_| Ok(()));
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
         let cmd = DeleteTaskCommand {
             name: "task:1".into(),
         };
@@ -64,7 +67,10 @@ mod tests {
         let mut mock = MockMemoryRepository::new();
         mock.expect_delete_entities().never();
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
         let cmd = DeleteTaskCommand {
             name: String::new(),
         };

--- a/crates/mm-core/src/operations/memory/tasks/get_task.rs
+++ b/crates/mm-core/src/operations/memory/tasks/get_task.rs
@@ -53,7 +53,10 @@ mod tests {
             .returning(move |_| Ok(Some(entity.clone())));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
 
         let cmd = GetTaskCommand {
             name: "task:1".into(),
@@ -67,7 +70,10 @@ mod tests {
         let mut mock = MockMemoryRepository::new();
         mock.expect_find_entity_by_name().never();
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
 
         let cmd = GetTaskCommand {
             name: String::new(),

--- a/crates/mm-core/src/operations/memory/tasks/update_task.rs
+++ b/crates/mm-core/src/operations/memory/tasks/update_task.rs
@@ -47,7 +47,10 @@ mod tests {
             .returning(|_, _| Ok(()));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
 
         let cmd = UpdateTaskCommand {
             name: "task:1".into(),
@@ -62,7 +65,10 @@ mod tests {
         let mut mock = MockMemoryRepository::new();
         mock.expect_update_entity().never();
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
         let cmd = UpdateTaskCommand {
             name: String::new(),
             update: EntityUpdate::default(),

--- a/crates/mm-core/src/operations/memory/update_entity.rs
+++ b/crates/mm-core/src/operations/memory/update_entity.rs
@@ -46,7 +46,10 @@ mod tests {
             .withf(|n, _| n == "test:entity")
             .returning(|_, _| Ok(()));
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
         let cmd = UpdateEntityCommand {
             name: "test:entity".into(),
             update: EntityUpdate::default(),
@@ -60,7 +63,10 @@ mod tests {
         let mut mock = MockMemoryRepository::new();
         mock.expect_update_entity().never();
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
         let cmd = UpdateEntityCommand {
             name: "".into(),
             update: EntityUpdate::default(),

--- a/crates/mm-core/src/operations/memory/update_relationship.rs
+++ b/crates/mm-core/src/operations/memory/update_relationship.rs
@@ -49,7 +49,10 @@ mod tests {
             .withf(|f, t, n, _| f == "a" && t == "b" && n == "rel")
             .returning(|_, _, _, _| Ok(()));
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
         let cmd = UpdateRelationshipCommand {
             from: "a".into(),
             to: "b".into(),
@@ -65,7 +68,10 @@ mod tests {
         let mut mock = MockMemoryRepository::new();
         mock.expect_update_relationship().never();
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
+        let ports = Ports {
+            memory_service: Arc::new(service),
+            ..Ports::new_noop()
+        };
         let cmd = UpdateRelationshipCommand {
             from: "".into(),
             to: "b".into(),

--- a/crates/mm-core/src/operations/mod.rs
+++ b/crates/mm-core/src/operations/mod.rs
@@ -1,1 +1,5 @@
+pub mod git;
 pub mod memory;
+
+pub use git::*;
+pub use memory::*;

--- a/crates/mm-core/src/ports.rs
+++ b/crates/mm-core/src/ports.rs
@@ -8,7 +8,7 @@ use crate::RootCollection;
 ///
 /// This struct serves as a dependency injection container for all operations.
 /// Each operation function will receive this struct to access the services it needs.
-pub struct Ports<MR, GR>
+pub struct Ports<MR, GR = ()>
 where
     MR: MemoryRepository + Send + Sync + 'static,
     GR: GitRepository + Send + Sync + 'static,

--- a/crates/mm-core/src/ports.rs
+++ b/crates/mm-core/src/ports.rs
@@ -48,3 +48,20 @@ where
         }
     }
 }
+
+#[cfg(any(test, feature = "mock"))]
+impl Ports<mm_memory::MockMemoryRepository, mm_git::repository::MockGitRepository> {
+    /// Create a new `Ports` instance using noop mock repositories.
+    ///
+    /// This helper is useful in tests where only a subset of services are
+    /// needed. The returned instance provides mock services that do nothing
+    /// unless expectations are explicitly set.
+    pub fn new_noop() -> Self {
+        let memory_service = Arc::new(MemoryService::new(
+            mm_memory::MockMemoryRepository::new(),
+            mm_memory::MemoryConfig::default(),
+        ));
+        let git_service = Arc::new(GitService::new(mm_git::repository::MockGitRepository::new()));
+        Self::new(memory_service, git_service)
+    }
+}

--- a/crates/mm-core/src/ports.rs
+++ b/crates/mm-core/src/ports.rs
@@ -1,3 +1,4 @@
+use mm_git::{GitRepository, GitService};
 use mm_memory::{MemoryRepository, MemoryService};
 use std::sync::{Arc, RwLock};
 
@@ -7,36 +8,43 @@ use crate::RootCollection;
 ///
 /// This struct serves as a dependency injection container for all operations.
 /// Each operation function will receive this struct to access the services it needs.
-pub struct Ports<R>
+pub struct Ports<MR, GR>
 where
-    R: MemoryRepository + Send + Sync + 'static,
+    MR: MemoryRepository + Send + Sync + 'static,
+    GR: GitRepository + Send + Sync + 'static,
 {
     /// Memory service for entity operations
-    pub memory_service: Arc<MemoryService<R>>,
+    pub memory_service: Arc<MemoryService<MR>>,
+    /// Git service for repository operations
+    pub git_service: Arc<GitService<GR>>,
     /// Collection of client-provided roots
     pub roots: Arc<RwLock<RootCollection>>,
 }
 
-impl<R> Ports<R>
+impl<MR, GR> Ports<MR, GR>
 where
-    R: MemoryRepository + Send + Sync + 'static,
+    MR: MemoryRepository + Send + Sync + 'static,
+    GR: GitRepository + Send + Sync + 'static,
 {
-    /// Create a new Ports instance with the given memory service and roots
+    /// Create a new `Ports` instance with the given services and empty roots
+    pub fn new(memory_service: Arc<MemoryService<MR>>, git_service: Arc<GitService<GR>>) -> Self {
+        Self {
+            memory_service,
+            git_service,
+            roots: Arc::new(RwLock::new(RootCollection::default())),
+        }
+    }
+
+    /// Create a new `Ports` instance with the given services and roots
     pub fn with_roots(
-        memory_service: Arc<MemoryService<R>>,
+        memory_service: Arc<MemoryService<MR>>,
+        git_service: Arc<GitService<GR>>,
         roots: Arc<RwLock<RootCollection>>,
     ) -> Self {
         Self {
             memory_service,
+            git_service,
             roots,
         }
-    }
-
-    /// Backwards-compatible constructor that creates empty roots
-    pub fn new(memory_service: Arc<MemoryService<R>>) -> Self {
-        Self::with_roots(
-            memory_service,
-            Arc::new(RwLock::new(RootCollection::default())),
-        )
     }
 }

--- a/crates/mm-git/Cargo.toml
+++ b/crates/mm-git/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "mm-git"
+version = "0.1.0"
+edition = "2024"
+license = "MPL-2.0"
+
+[dependencies]
+async-trait = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+schemars = { workspace = true, features = ["derive"] }
+thiserror = { workspace = true }
+mockall = { workspace = true, optional = true }
+
+[dev-dependencies]
+mockall = { workspace = true }
+tokio = { workspace = true, features = ["full", "test-util"] }
+
+[features]
+mock = ["mockall"]

--- a/crates/mm-git/src/error.rs
+++ b/crates/mm-git/src/error.rs
@@ -1,0 +1,38 @@
+use std::error::Error as StdError;
+use thiserror::Error;
+
+/// Errors that can occur when interacting with Git repositories
+#[derive(Error, Debug)]
+pub enum GitError<E>
+where
+    E: StdError + Send + Sync + 'static,
+{
+    /// Error accessing the Git repository
+    #[error("Repository error: {message}")]
+    RepositoryError {
+        message: String,
+        #[source]
+        source: Option<E>,
+    },
+}
+
+impl<E> GitError<E>
+where
+    E: StdError + Send + Sync + 'static,
+{
+    pub fn repository_error<S: Into<String>>(message: S) -> Self {
+        Self::RepositoryError {
+            message: message.into(),
+            source: None,
+        }
+    }
+
+    pub fn repository_error_with_source<S: Into<String>>(message: S, source: E) -> Self {
+        Self::RepositoryError {
+            message: message.into(),
+            source: Some(source),
+        }
+    }
+}
+
+pub type GitResult<T, E> = Result<T, GitError<E>>;

--- a/crates/mm-git/src/lib.rs
+++ b/crates/mm-git/src/lib.rs
@@ -1,0 +1,11 @@
+#![warn(clippy::all)]
+
+pub mod error;
+pub mod repository;
+pub mod service;
+pub mod status;
+
+pub use error::{GitError, GitResult};
+pub use repository::GitRepository;
+pub use service::GitService;
+pub use status::GitStatus;

--- a/crates/mm-git/src/repository.rs
+++ b/crates/mm-git/src/repository.rs
@@ -1,0 +1,26 @@
+use async_trait::async_trait;
+use std::error::Error as StdError;
+use std::path::Path;
+
+use crate::error::GitResult;
+use crate::status::GitStatus;
+
+#[cfg_attr(any(test, feature = "mock"), mockall::automock(type Error = std::convert::Infallible;))]
+#[async_trait]
+pub trait GitRepository {
+    type Error: StdError + Send + Sync + 'static;
+
+    /// Get the status of a Git repository
+    async fn get_status(&self, path: &Path) -> GitResult<GitStatus, Self::Error>;
+}
+
+#[async_trait]
+impl GitRepository for () {
+    type Error = std::convert::Infallible;
+
+    async fn get_status(&self, _path: &Path) -> GitResult<GitStatus, Self::Error> {
+        Err(crate::error::GitError::repository_error(
+            "No Git repository configured",
+        ))
+    }
+}

--- a/crates/mm-git/src/service.rs
+++ b/crates/mm-git/src/service.rs
@@ -1,0 +1,51 @@
+use std::path::Path;
+
+use crate::error::GitResult;
+use crate::repository::GitRepository;
+use crate::status::GitStatus;
+
+/// Service for Git operations
+pub struct GitService<R>
+where
+    R: GitRepository,
+{
+    /// The repository used to perform Git operations
+    repository: R,
+}
+
+impl<R> GitService<R>
+where
+    R: GitRepository + Sync,
+{
+    /// Create a new Git service with the given repository
+    pub fn new(repository: R) -> Self {
+        Self { repository }
+    }
+
+    /// Get the status of a Git repository
+    pub async fn get_status(&self, path: &Path) -> GitResult<GitStatus, R::Error> {
+        self.repository.get_status(path).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repository::MockGitRepository;
+
+    #[tokio::test]
+    async fn test_get_status() {
+        let mut mock = MockGitRepository::new();
+        mock.expect_get_status()
+            .withf(|p| p.to_str() == Some("/tmp"))
+            .returning(|_| {
+                Ok(GitStatus {
+                    branch: "main".to_string(),
+                })
+            });
+
+        let service = GitService::new(mock);
+        let status = service.get_status(Path::new("/tmp")).await.unwrap();
+        assert_eq!(status.branch, "main");
+    }
+}

--- a/crates/mm-git/src/status.rs
+++ b/crates/mm-git/src/status.rs
@@ -1,0 +1,9 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Represents the status of a Git repository
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Default)]
+pub struct GitStatus {
+    /// Current branch name
+    pub branch: String,
+}

--- a/crates/mm-server/src/mcp/create_entities.rs
+++ b/crates/mm-server/src/mcp/create_entities.rs
@@ -37,6 +37,7 @@ impl CreateEntitiesTool {
 mod tests {
     use super::*;
     use mm_core::Ports;
+    use mm_core::mm_git::GitService;
     use mm_memory::{MemoryConfig, MemoryError, MemoryService, MockMemoryRepository};
     use std::sync::Arc;
 
@@ -55,7 +56,7 @@ mod tests {
                 ..MemoryConfig::default()
             },
         );
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
 
         let tool = CreateEntitiesTool {
             entities: vec![MemoryEntity {
@@ -86,7 +87,7 @@ mod tests {
             .returning(|_| Err(MemoryError::runtime_error("fail")));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
 
         let tool = CreateEntitiesTool {
             entities: vec![MemoryEntity {

--- a/crates/mm-server/src/mcp/create_relationships.rs
+++ b/crates/mm-server/src/mcp/create_relationships.rs
@@ -59,6 +59,7 @@ impl CreateRelationshipsTool {
 mod tests {
     use super::*;
     use mm_core::Ports;
+    use mm_core::mm_git::GitService;
     use mm_memory::{MemoryConfig, MemoryError, MemoryService, MockMemoryRepository};
     use std::sync::Arc;
 
@@ -70,7 +71,7 @@ mod tests {
             .returning(|_| Ok(()));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
 
         let tool = CreateRelationshipsTool {
             relationships: vec![RelationshipInput {
@@ -93,7 +94,7 @@ mod tests {
             .returning(|_| Err(MemoryError::runtime_error("fail")));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
 
         let tool = CreateRelationshipsTool {
             relationships: vec![RelationshipInput {

--- a/crates/mm-server/src/mcp/error.rs
+++ b/crates/mm-server/src/mcp/error.rs
@@ -40,11 +40,12 @@ impl StdError for ToolError {
     }
 }
 
-impl<E> From<CoreError<E>> for ToolError
+impl<ME, GE> From<CoreError<ME, GE>> for ToolError
 where
-    E: StdError + Send + Sync + 'static,
+    ME: StdError + Send + Sync + 'static,
+    GE: StdError + Send + Sync + 'static,
 {
-    fn from(error: CoreError<E>) -> Self {
+    fn from(error: CoreError<ME, GE>) -> Self {
         let message = match &error {
             CoreError::Memory(e) => e.to_string(),
             CoreError::Serialization(e) => e.to_string(),
@@ -54,6 +55,7 @@ where
                 .map(|(name, err)| format!("{}: {}", name, err))
                 .collect::<Vec<_>>()
                 .join("; "),
+            CoreError::Git(e) => e.to_string(),
             CoreError::MissingProject => "No project specified".to_string(),
         };
         Self::with_source(message, error)

--- a/crates/mm-server/src/mcp/get_entity.rs
+++ b/crates/mm-server/src/mcp/get_entity.rs
@@ -43,6 +43,7 @@ impl GetEntityTool {
 mod tests {
     use super::*;
     use mm_core::Ports;
+    use mm_core::mm_git::GitService;
     use mm_memory::{MemoryConfig, MemoryEntity, MemoryError, MemoryService, MockMemoryRepository};
     use mockall::predicate::*;
     use serde_json::Value;
@@ -62,7 +63,7 @@ mod tests {
             .returning(move |_| Ok(Some(entity.clone())));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
 
         let tool = GetEntityTool {
             name: "test:entity".to_string(),
@@ -82,7 +83,7 @@ mod tests {
             .returning(|_| Err(MemoryError::query_error("fail")));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
 
         let tool = GetEntityTool {
             name: "test:entity".to_string(),
@@ -100,7 +101,7 @@ mod tests {
             .returning(|_| Ok(None));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
 
         let tool = GetEntityTool {
             name: "missing".to_string(),

--- a/crates/mm-server/src/mcp/get_project_context.rs
+++ b/crates/mm-server/src/mcp/get_project_context.rs
@@ -53,6 +53,7 @@ impl GetProjectContextTool {
 mod tests {
     use super::*;
     use mm_core::Ports;
+    use mm_core::mm_git::GitService;
     use mm_memory::{MemoryConfig, MemoryEntity, MemoryService, MockMemoryRepository};
     use mockall::predicate::*;
     use serde_json::Value;
@@ -109,7 +110,7 @@ mod tests {
 
         // Create service and ports
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
 
         // Create and call tool
         let tool = GetProjectContextTool {
@@ -130,7 +131,7 @@ mod tests {
     async fn test_call_tool_missing_parameters() {
         let mock = MockMemoryRepository::new();
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
 
         let tool = GetProjectContextTool {
             project_name: None,

--- a/crates/mm-server/src/mcp/list_projects.rs
+++ b/crates/mm-server/src/mcp/list_projects.rs
@@ -36,6 +36,7 @@ impl ListProjectsTool {
 mod tests {
     use super::*;
     use mm_core::Ports;
+    use mm_core::mm_git::GitService;
     use mm_memory::{MemoryConfig, MemoryEntity, MemoryService, MockMemoryRepository};
     use mockall::predicate::*;
     use serde_json::Value;
@@ -70,7 +71,7 @@ mod tests {
             .returning(move |_, _, _| Ok(vec![project1.clone(), project2.clone()]));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
 
         let tool = ListProjectsTool { name_filter: None };
 
@@ -110,7 +111,7 @@ mod tests {
             .returning(move |_, _, _| Ok(vec![project1.clone(), project2.clone()]));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
 
         let tool = ListProjectsTool {
             name_filter: Some("flakes".to_string()),

--- a/crates/mm-server/src/mcp/macros.rs
+++ b/crates/mm-server/src/mcp/macros.rs
@@ -33,10 +33,11 @@ macro_rules! generate_call_tool {
 
     // Custom success block version that provides both the command and the result
     ($self_ident:ident, $command:ident { $( $field:ident $(=> $value:expr)? ),* $(,)? }, $operation:path, |$cmd_ident:ident, $res_ident:ident| $success_block:block) => {
-        pub async fn call_tool<R>(&$self_ident, ports: &mm_core::Ports<R>) -> Result<rust_mcp_sdk::schema::CallToolResult, rust_mcp_sdk::schema::schema_utils::CallToolError>
+        pub async fn call_tool<R, G>(&$self_ident, ports: &mm_core::Ports<R, G>) -> Result<rust_mcp_sdk::schema::CallToolResult, rust_mcp_sdk::schema::schema_utils::CallToolError>
         where
             R: mm_memory::MemoryRepository + Send + Sync,
             R::Error: std::error::Error + Send + Sync + 'static,
+            G: mm_core::mm_git::GitRepository + Send + Sync,
         {
             use tracing::Instrument;
 

--- a/crates/mm-server/src/mcp/update_entity.rs
+++ b/crates/mm-server/src/mcp/update_entity.rs
@@ -26,6 +26,7 @@ impl UpdateEntityTool {
 mod tests {
     use super::*;
     use mm_core::Ports;
+    use mm_core::mm_git::GitService;
     use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
     use std::sync::Arc;
 
@@ -36,7 +37,7 @@ mod tests {
             .withf(|n, _| n == "e")
             .returning(|_, _| Ok(()));
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
         let tool = UpdateEntityTool {
             name: "e".into(),
             update: EntityUpdate::default(),

--- a/crates/mm-server/src/mcp/update_relationship.rs
+++ b/crates/mm-server/src/mcp/update_relationship.rs
@@ -43,6 +43,7 @@ impl UpdateRelationshipTool {
 mod tests {
     use super::*;
     use mm_core::Ports;
+    use mm_core::mm_git::GitService;
     use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
     use std::sync::Arc;
 
@@ -53,7 +54,7 @@ mod tests {
             .withf(|f, t, n, _| f == "a" && t == "b" && n == "rel")
             .returning(|_, _, _, _| Ok(()));
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
         let tool = UpdateRelationshipTool {
             from: "a".into(),
             to: "b".into(),

--- a/crates/mm-server/src/resources.rs
+++ b/crates/mm-server/src/resources.rs
@@ -1,4 +1,5 @@
 use mm_core::Ports;
+use mm_core::mm_git::GitRepository;
 use mm_core::operations::memory::{GetEntityCommand, get_entity};
 use mm_memory::MemoryRepository;
 use rust_mcp_sdk::schema::{
@@ -32,10 +33,14 @@ pub fn list_resources() -> ListResourcesResult {
 
 /// Read a memory entity from the given URI.
 #[tracing::instrument(skip(ports), fields(uri))]
-pub async fn read_resource<R>(ports: &Ports<R>, uri: &str) -> Result<ReadResourceResult, RpcError>
+pub async fn read_resource<MR, GR>(
+    ports: &Ports<MR, GR>,
+    uri: &str,
+) -> Result<ReadResourceResult, RpcError>
 where
-    R: MemoryRepository + Send + Sync,
-    R::Error: std::error::Error + Send + Sync + 'static,
+    MR: MemoryRepository + Send + Sync,
+    MR::Error: std::error::Error + Send + Sync + 'static,
+    GR: GitRepository + Send + Sync,
 {
     let Some(name) = uri.strip_prefix("memory://") else {
         return Err(RpcError::invalid_params().with_message("Unsupported URI".to_string()));
@@ -74,6 +79,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mm_core::mm_git::GitService;
     use mm_memory::{MemoryConfig, MemoryEntity, MemoryService, MockMemoryRepository};
     use mockall::predicate::*;
     use std::sync::Arc;
@@ -92,7 +98,7 @@ mod tests {
             .returning(move |_| Ok(Some(entity.clone())));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
 
         let result = read_resource(&ports, "memory://test:entity").await.unwrap();
         if let ReadResourceResultContentsItem::TextResourceContents(contents) = &result.contents[0]
@@ -110,7 +116,7 @@ mod tests {
             .with(eq("missing"))
             .returning(|_| Ok(None));
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
         let err = read_resource(&ports, "memory://missing").await.unwrap_err();
         assert_eq!(err.message, "Entity 'missing' not found");
     }
@@ -119,7 +125,7 @@ mod tests {
     async fn test_read_resource_invalid_uri() {
         let mock = MockMemoryRepository::new();
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let ports = Ports::new(Arc::new(service));
+        let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
         let err = read_resource(&ports, "file://foo").await.unwrap_err();
         assert_eq!(err.message, "Unsupported URI");
     }
@@ -129,6 +135,7 @@ mod tests {
 mod prop_tests {
     use super::*;
     use arbitrary::{Arbitrary, Unstructured};
+    use mm_core::mm_git::GitService;
     use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
     use mm_utils::prop::{NonEmptyName, async_arbtest};
     use std::sync::Arc;
@@ -144,7 +151,7 @@ mod prop_tests {
                 .withf(move |n| n == name_clone)
                 .returning(|_| Ok(None));
             let service = MemoryService::new(mock, MemoryConfig::default());
-            let ports = Ports::new(Arc::new(service));
+            let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
             let err = rt.block_on(read_resource(&ports, &uri)).unwrap_err();
             assert_eq!(err.message, format!("Entity '{}' not found", name));
             Ok(())
@@ -171,7 +178,7 @@ mod prop_tests {
             let mut mock = MockMemoryRepository::new();
             mock.expect_find_entity_by_name().never();
             let service = MemoryService::new(mock, MemoryConfig::default());
-            let ports = Ports::new(Arc::new(service));
+            let ports = Ports::new(Arc::new(service), Arc::new(GitService::new(())));
             let err = rt.block_on(read_resource(&ports, &uri)).unwrap_err();
             assert_eq!(err.message, "Unsupported URI");
             Ok(())


### PR DESCRIPTION
## Summary
- add new `mm-git` crate with repository, service and status types
- integrate Git service into core `Ports` and operations
- update server and tests to pass Git service instance
- support PathBuf in git status command
- adjust error generics for separate memory and git errors

## Testing
- `cargo check --workspace --tests`
- `cargo test --workspace --lib`
- `just clippy`
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_685adb3a51ac8327b2c6d4dd9c3bb416