### PR TITLE
Add git2 repository adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,6 +708,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,6 +887,21 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "git2"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232e6a7bfe35766bf715e55a88b39a700596c0ccfd88cd3680b4cdb40d66ef70"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
 
 [[package]]
 name = "glob"
@@ -1288,6 +1309,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.16.2+1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,10 +1333,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -1440,6 +1507,17 @@ dependencies = [
  "schemars",
  "serde",
  "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
+name = "mm-git-git2"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "git2",
+ "mm-git",
+ "tempfile",
  "tokio",
 ]
 
@@ -1647,6 +1725,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-sys"
+version = "0.9.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1805,6 +1895,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "potential_utf"
@@ -2257,7 +2353,20 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -2590,6 +2699,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix 1.0.7",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3006,6 +3128,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3166,7 +3294,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/mm-memory",
     "crates/mm-memory-neo4j",
     "crates/mm-git",
+    "crates/mm-git-git2",
     "crates/mm-server",
     "crates/mm-utils",
 ]

--- a/crates/mm-git-git2/Cargo.toml
+++ b/crates/mm-git-git2/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "mm-git-git2"
+version = "0.1.0"
+edition = "2024"
+license = "MPL-2.0"
+
+[dependencies]
+mm-git = { path = "../mm-git" }
+async-trait = { workspace = true }
+tokio = { workspace = true, features = ["rt"] }
+git2 = "0.18"
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/mm-git-git2/src/lib.rs
+++ b/crates/mm-git-git2/src/lib.rs
@@ -1,0 +1,12 @@
+#![warn(clippy::all)]
+
+mod repository;
+
+pub use repository::Git2Repository;
+
+use mm_git::GitService;
+
+/// Create a new GitService with a Git2Repository
+pub fn create_git_service() -> GitService<Git2Repository> {
+    GitService::new(Git2Repository::new())
+}

--- a/crates/mm-git-git2/src/repository.rs
+++ b/crates/mm-git-git2/src/repository.rs
@@ -1,0 +1,35 @@
+use async_trait::async_trait;
+use git2::Repository;
+use mm_git::{GitError, GitRepository, GitResult, GitStatus};
+use std::path::{Path, PathBuf};
+use tokio::task;
+
+pub struct Git2Repository;
+
+impl Git2Repository {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl GitRepository for Git2Repository {
+    type Error = git2::Error;
+
+    async fn get_status(&self, path: &Path) -> GitResult<GitStatus, Self::Error> {
+        let path: PathBuf = path.to_path_buf();
+        let res = task::spawn_blocking(move || -> Result<GitStatus, git2::Error> {
+            let repo = Repository::open(path)?;
+            let head = repo.head()?;
+            let branch = head
+                .shorthand()
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| "HEAD".to_string());
+            Ok(GitStatus { branch })
+        })
+        .await
+        .map_err(|e| GitError::repository_error(format!("Task join error: {e}")))?;
+
+        res.map_err(|e| GitError::repository_error_with_source("Git operation failed", e))
+    }
+}

--- a/crates/mm-git-git2/tests/git2_repository.rs
+++ b/crates/mm-git-git2/tests/git2_repository.rs
@@ -1,0 +1,38 @@
+use git2::{Repository, Signature};
+use mm_git::{GitError, GitRepository};
+use mm_git_git2::{Git2Repository, create_git_service};
+use tempfile::TempDir;
+
+fn init_repo(dir: &TempDir) -> Repository {
+    let mut opts = git2::RepositoryInitOptions::new();
+    opts.initial_head("main");
+    let repo = Repository::init_opts(dir.path(), &opts).expect("init repo");
+    let sig = Signature::now("Test", "test@example.com").unwrap();
+    let tree_id = {
+        let mut index = repo.index().unwrap();
+        index.write_tree().unwrap()
+    };
+    let tree = repo.find_tree(tree_id).unwrap();
+    repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+        .unwrap();
+    drop(tree);
+    repo
+}
+
+#[tokio::test]
+async fn test_get_status_success() {
+    let dir = TempDir::new().unwrap();
+    let repo = init_repo(&dir);
+    let expected_branch = repo.head().unwrap().shorthand().unwrap().to_string();
+    let service = create_git_service();
+    let status = service.get_status(dir.path()).await.unwrap();
+    assert_eq!(status.branch, expected_branch);
+}
+
+#[tokio::test]
+async fn test_get_status_invalid_path() {
+    let repo = Git2Repository::new();
+    let path = std::path::Path::new("/nonexistent/path");
+    let result = repo.get_status(path).await;
+    assert!(matches!(result, Err(GitError::RepositoryError { .. })));
+}


### PR DESCRIPTION
## Summary
- implement Git2Repository in new `mm-git-git2` crate
- provide a factory `create_git_service` using the git2 backend
- add unit tests for Git2Repository

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_685b0e8e9cc08327bd0be48f337cdd6e