### PR TITLE
Add task dependency checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,6 +1487,7 @@ dependencies = [
  "arbtest",
  "async-trait",
  "chrono",
+ "futures",
  "mm-memory",
  "mm-utils",
  "mockall",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,6 +708,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,6 +887,21 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "git2"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232e6a7bfe35766bf715e55a88b39a700596c0ccfd88cd3680b4cdb40d66ef70"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
 
 [[package]]
 name = "glob"
@@ -1288,6 +1309,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.16.2+1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,10 +1333,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -1440,6 +1507,17 @@ dependencies = [
  "schemars",
  "serde",
  "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
+name = "mm-git-git2"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "git2",
+ "mm-git",
+ "tempfile",
  "tokio",
 ]
 
@@ -1647,6 +1725,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-sys"
+version = "0.9.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1805,6 +1895,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "potential_utf"
@@ -2257,7 +2353,20 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -2590,6 +2699,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix 1.0.7",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3006,6 +3128,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3166,7 +3294,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,6 +1432,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mm-git"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "mockall",
+ "schemars",
+ "serde",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "mm-memory"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/mm-core",
     "crates/mm-memory",
     "crates/mm-memory-neo4j",
+    "crates/mm-git",
     "crates/mm-server",
     "crates/mm-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/mm-memory",
     "crates/mm-memory-neo4j",
     "crates/mm-git",
+    "crates/mm-git-git2",
     "crates/mm-server",
     "crates/mm-utils",
 ]

--- a/crates/mm-core/Cargo.toml
+++ b/crates/mm-core/Cargo.toml
@@ -13,6 +13,7 @@ tracing = { workspace = true }
 async-trait = { workspace = true }
 schemars = { workspace = true }
 chrono = { workspace = true }
+futures = "0.3"
 
 [dev-dependencies]
 mockall = { workspace = true }

--- a/crates/mm-core/src/operations/memory/tasks/create_task.rs
+++ b/crates/mm-core/src/operations/memory/tasks/create_task.rs
@@ -2,8 +2,9 @@ use super::types::TaskProperties;
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
 use crate::validate_name;
+use futures::future::try_join_all;
 use mm_memory::MemoryRepository;
-use mm_memory::{MemoryEntity, MemoryRelationship};
+use mm_memory::{MemoryEntity, MemoryRelationship, ValidationError, ValidationErrorKind};
 use std::collections::HashMap;
 use tracing::instrument;
 
@@ -11,6 +12,7 @@ use tracing::instrument;
 pub struct CreateTaskCommand {
     pub task: MemoryEntity<TaskProperties>,
     pub project_name: Option<String>,
+    pub depends_on: Vec<String>,
 }
 
 pub type CreateTaskResult<E> = CoreResult<(), E>;
@@ -34,6 +36,31 @@ where
         None => return Err(CoreError::MissingProject),
     };
 
+    // Validate dependency names and ensure they exist
+    if command.depends_on.iter().any(|d| d == &command.task.name) {
+        return Err(CoreError::Validation(ValidationError(vec![
+            ValidationErrorKind::ConflictingOperations("depends_on"),
+        ])));
+    }
+
+    for dep in &command.depends_on {
+        validate_name!(dep);
+    }
+
+    let lookups = command
+        .depends_on
+        .iter()
+        .map(|name| ports.memory_service.find_entity_by_name(name));
+    let results = try_join_all(lookups).await.map_err(CoreError::from)?;
+
+    for (dep, found) in command.depends_on.iter().zip(results) {
+        if found.is_none() {
+            return Err(CoreError::Memory(mm_memory::MemoryError::entity_not_found(
+                dep.clone(),
+            )));
+        }
+    }
+
     let task = command.task;
     let task_name = task.name.clone();
 
@@ -47,16 +74,25 @@ where
         return Err(CoreError::BatchValidation(errors));
     }
 
-    let relationship = MemoryRelationship {
+    let mut relationships = vec![MemoryRelationship {
         from: project_name,
-        to: task_name,
+        to: task_name.clone(),
         name: "contains".to_string(),
         properties: HashMap::default(),
-    };
+    }];
+
+    for dep in &command.depends_on {
+        relationships.push(MemoryRelationship {
+            from: task_name.clone(),
+            to: dep.clone(),
+            name: "depends_on".to_string(),
+            properties: HashMap::default(),
+        });
+    }
 
     let errors = ports
         .memory_service
-        .create_relationships(std::slice::from_ref(&relationship))
+        .create_relationships(&relationships)
         .await
         .map_err(CoreError::from)?;
 
@@ -70,7 +106,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository, ValidationErrorKind};
+    use mm_memory::{
+        MemoryConfig, MemoryError, MemoryService, MockMemoryRepository, ValidationErrorKind,
+    };
+    use mockall::predicate::*;
+    use std::collections::HashSet;
     use std::sync::Arc;
 
     #[tokio::test]
@@ -92,6 +132,8 @@ mod tests {
             mock,
             MemoryConfig {
                 default_project: Some("proj".into()),
+                additional_relationships: std::iter::once("depends_on".to_string())
+                    .collect::<HashSet<_>>(),
                 ..MemoryConfig::default()
             },
         );
@@ -104,6 +146,7 @@ mod tests {
                 ..Default::default()
             },
             project_name: None,
+            depends_on: Vec::new(),
         };
 
         let res = create_task(&ports, cmd).await;
@@ -126,6 +169,7 @@ mod tests {
                 ..Default::default()
             },
             project_name: None,
+            depends_on: Vec::new(),
         };
 
         let res = create_task(&ports, cmd).await;
@@ -135,6 +179,94 @@ mod tests {
     #[tokio::test]
     async fn test_create_task_empty_name() {
         let mut mock = MockMemoryRepository::new();
+        mock.expect_create_entities().never();
+        mock.expect_create_relationships().never();
+        mock.expect_find_entity_by_name().never();
+
+        let service = MemoryService::new(
+            mock,
+            MemoryConfig {
+                default_project: Some("proj".into()),
+                additional_relationships: std::iter::once("depends_on".to_string())
+                    .collect::<HashSet<_>>(),
+                ..MemoryConfig::default()
+            },
+        );
+        let ports = Ports::new(Arc::new(service));
+
+        let cmd = CreateTaskCommand {
+            task: MemoryEntity::<TaskProperties> {
+                name: String::new(),
+                labels: vec!["Task".into()],
+                ..Default::default()
+            },
+            project_name: None,
+            depends_on: Vec::new(),
+        };
+
+        let res = create_task(&ports, cmd).await;
+        assert!(
+            matches!(res, Err(CoreError::Validation(ref e)) if e.0.contains(&ValidationErrorKind::EmptyEntityName))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_task_with_dependencies() {
+        let mut mock = MockMemoryRepository::new();
+
+        mock.expect_find_entity_by_name()
+            .with(eq("task:dep"))
+            .times(1)
+            .returning(|_| Ok(Some(MemoryEntity::default())));
+
+        mock.expect_create_entities()
+            .withf(|e| e.len() == 1 && e[0].name == "task:1")
+            .returning(|_| Ok(()));
+
+        mock.expect_create_relationships()
+            .withf(|r| {
+                r.len() == 2
+                    && r[0].name == "contains"
+                    && r[1].name == "depends_on"
+                    && r[1].to == "task:dep"
+                    && r[1].from == "task:1"
+            })
+            .returning(|_| Ok(()));
+
+        let service = MemoryService::new(
+            mock,
+            MemoryConfig {
+                default_project: Some("proj".into()),
+                additional_relationships: std::iter::once("depends_on".to_string())
+                    .collect::<HashSet<_>>(),
+                ..MemoryConfig::default()
+            },
+        );
+        let ports = Ports::new(Arc::new(service));
+
+        let cmd = CreateTaskCommand {
+            task: MemoryEntity::<TaskProperties> {
+                name: "task:1".into(),
+                labels: vec!["Task".into()],
+                ..Default::default()
+            },
+            project_name: None,
+            depends_on: vec!["task:dep".into()],
+        };
+
+        let res = create_task(&ports, cmd).await;
+        assert!(res.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_create_task_dependency_missing() {
+        let mut mock = MockMemoryRepository::new();
+
+        mock.expect_find_entity_by_name()
+            .with(eq("task:missing"))
+            .times(1)
+            .returning(|_| Ok(None));
+
         mock.expect_create_entities().never();
         mock.expect_create_relationships().never();
 
@@ -149,16 +281,50 @@ mod tests {
 
         let cmd = CreateTaskCommand {
             task: MemoryEntity::<TaskProperties> {
-                name: String::new(),
+                name: "task:1".into(),
                 labels: vec!["Task".into()],
                 ..Default::default()
             },
             project_name: None,
+            depends_on: vec!["task:missing".into()],
         };
 
         let res = create_task(&ports, cmd).await;
-        assert!(
-            matches!(res, Err(CoreError::Validation(ref e)) if e.0.contains(&ValidationErrorKind::EmptyEntityName))
+        assert!(matches!(
+            res,
+            Err(CoreError::Memory(MemoryError::EntityNotFound(_)))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_create_task_self_dependency() {
+        let mut mock = MockMemoryRepository::new();
+        mock.expect_find_entity_by_name().never();
+        mock.expect_create_entities().never();
+        mock.expect_create_relationships().never();
+
+        let service = MemoryService::new(
+            mock,
+            MemoryConfig {
+                default_project: Some("proj".into()),
+                additional_relationships: std::iter::once("depends_on".to_string())
+                    .collect::<HashSet<_>>(),
+                ..MemoryConfig::default()
+            },
         );
+        let ports = Ports::new(Arc::new(service));
+
+        let cmd = CreateTaskCommand {
+            task: MemoryEntity::<TaskProperties> {
+                name: "task:1".into(),
+                labels: vec!["Task".into()],
+                ..Default::default()
+            },
+            project_name: None,
+            depends_on: vec!["task:1".into()],
+        };
+
+        let res = create_task(&ports, cmd).await;
+        assert!(matches!(res, Err(CoreError::Validation(_))));
     }
 }

--- a/crates/mm-git-git2/Cargo.toml
+++ b/crates/mm-git-git2/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "mm-git-git2"
+version = "0.1.0"
+edition = "2024"
+license = "MPL-2.0"
+
+[dependencies]
+mm-git = { path = "../mm-git" }
+async-trait = { workspace = true }
+tokio = { workspace = true, features = ["rt"] }
+git2 = "0.18"
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/mm-git-git2/src/lib.rs
+++ b/crates/mm-git-git2/src/lib.rs
@@ -1,0 +1,12 @@
+#![warn(clippy::all)]
+
+mod repository;
+
+pub use repository::Git2Repository;
+
+use mm_git::GitService;
+
+/// Create a new GitService with a Git2Repository
+pub fn create_git_service() -> GitService<Git2Repository> {
+    GitService::new(Git2Repository::new())
+}

--- a/crates/mm-git-git2/src/repository.rs
+++ b/crates/mm-git-git2/src/repository.rs
@@ -1,0 +1,35 @@
+use async_trait::async_trait;
+use git2::Repository;
+use mm_git::{GitError, GitRepository, GitResult, GitStatus};
+use std::path::{Path, PathBuf};
+use tokio::task;
+
+pub struct Git2Repository;
+
+impl Git2Repository {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl GitRepository for Git2Repository {
+    type Error = git2::Error;
+
+    async fn get_status(&self, path: &Path) -> GitResult<GitStatus, Self::Error> {
+        let path: PathBuf = path.to_path_buf();
+        let res = task::spawn_blocking(move || -> Result<GitStatus, git2::Error> {
+            let repo = Repository::open(path)?;
+            let head = repo.head()?;
+            let branch = head
+                .shorthand()
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| "HEAD".to_string());
+            Ok(GitStatus { branch })
+        })
+        .await
+        .map_err(|e| GitError::repository_error(format!("Task join error: {e}")))?;
+
+        res.map_err(|e| GitError::repository_error_with_source("Git operation failed", e))
+    }
+}

--- a/crates/mm-git-git2/tests/git2_repository.rs
+++ b/crates/mm-git-git2/tests/git2_repository.rs
@@ -1,0 +1,38 @@
+use git2::{Repository, Signature};
+use mm_git::{GitError, GitRepository};
+use mm_git_git2::{Git2Repository, create_git_service};
+use tempfile::TempDir;
+
+fn init_repo(dir: &TempDir) -> Repository {
+    let mut opts = git2::RepositoryInitOptions::new();
+    opts.initial_head("main");
+    let repo = Repository::init_opts(dir.path(), &opts).expect("init repo");
+    let sig = Signature::now("Test", "test@example.com").unwrap();
+    let tree_id = {
+        let mut index = repo.index().unwrap();
+        index.write_tree().unwrap()
+    };
+    let tree = repo.find_tree(tree_id).unwrap();
+    repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+        .unwrap();
+    drop(tree);
+    repo
+}
+
+#[tokio::test]
+async fn test_get_status_success() {
+    let dir = TempDir::new().unwrap();
+    let repo = init_repo(&dir);
+    let expected_branch = repo.head().unwrap().shorthand().unwrap().to_string();
+    let service = create_git_service();
+    let status = service.get_status(dir.path()).await.unwrap();
+    assert_eq!(status.branch, expected_branch);
+}
+
+#[tokio::test]
+async fn test_get_status_invalid_path() {
+    let repo = Git2Repository::new();
+    let path = std::path::Path::new("/nonexistent/path");
+    let result = repo.get_status(path).await;
+    assert!(matches!(result, Err(GitError::RepositoryError { .. })));
+}

--- a/crates/mm-git/Cargo.toml
+++ b/crates/mm-git/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "mm-git"
+version = "0.1.0"
+edition = "2024"
+license = "MPL-2.0"
+
+[features]
+mock = ["mockall"]
+
+[dependencies]
+async-trait = { workspace = true }
+thiserror = { workspace = true }
+serde = { workspace = true }
+schemars = { workspace = true }
+mockall = { workspace = true, optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full", "test-util"] }
+mockall = { workspace = true }

--- a/crates/mm-git/src/error.rs
+++ b/crates/mm-git/src/error.rs
@@ -1,0 +1,38 @@
+use std::error::Error as StdError;
+use thiserror::Error;
+
+/// Errors that can occur when interacting with Git repositories
+#[derive(Error, Debug)]
+pub enum GitError<E>
+where
+    E: StdError + Send + Sync + 'static,
+{
+    /// Error accessing the Git repository
+    #[error("Repository error: {message}")]
+    RepositoryError {
+        message: String,
+        #[source]
+        source: Option<E>,
+    },
+}
+
+impl<E> GitError<E>
+where
+    E: StdError + Send + Sync + 'static,
+{
+    pub fn repository_error<S: Into<String>>(message: S) -> Self {
+        GitError::RepositoryError {
+            message: message.into(),
+            source: None,
+        }
+    }
+
+    pub fn repository_error_with_source<S: Into<String>>(message: S, source: E) -> Self {
+        GitError::RepositoryError {
+            message: message.into(),
+            source: Some(source),
+        }
+    }
+}
+
+pub type GitResult<T, E> = Result<T, GitError<E>>;

--- a/crates/mm-git/src/lib.rs
+++ b/crates/mm-git/src/lib.rs
@@ -1,0 +1,11 @@
+#![warn(clippy::all)]
+
+pub mod error;
+pub mod repository;
+pub mod service;
+pub mod status;
+
+pub use error::{GitError, GitResult};
+pub use repository::GitRepository;
+pub use service::GitService;
+pub use status::GitStatus;

--- a/crates/mm-git/src/repository.rs
+++ b/crates/mm-git/src/repository.rs
@@ -1,0 +1,15 @@
+use async_trait::async_trait;
+use std::error::Error as StdError;
+use std::path::Path;
+
+use crate::error::GitResult;
+use crate::status::GitStatus;
+
+#[cfg_attr(any(test, feature = "mock"), mockall::automock(type Error = std::convert::Infallible;))]
+#[async_trait]
+pub trait GitRepository {
+    type Error: StdError + Send + Sync + 'static;
+
+    /// Get the status of a Git repository
+    async fn get_status(&self, path: &Path) -> GitResult<GitStatus, Self::Error>;
+}

--- a/crates/mm-git/src/service.rs
+++ b/crates/mm-git/src/service.rs
@@ -1,0 +1,56 @@
+use std::path::Path;
+
+use crate::error::GitResult;
+use crate::repository::GitRepository;
+use crate::status::GitStatus;
+
+/// Service for Git operations
+pub struct GitService<R>
+where
+    R: GitRepository,
+{
+    /// The repository used to perform Git operations
+    repository: R,
+}
+
+impl<R> GitService<R>
+where
+    R: GitRepository + Sync,
+{
+    /// Create a new Git service with the given repository
+    pub fn new(repository: R) -> Self {
+        Self { repository }
+    }
+
+    /// Get the status of a Git repository
+    pub async fn get_status(&self, path: &Path) -> GitResult<GitStatus, R::Error> {
+        self.repository.get_status(path).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repository::MockGitRepository;
+    use std::path::PathBuf;
+
+    #[tokio::test]
+    async fn test_get_status() {
+        let mut mock = MockGitRepository::new();
+        let expected = GitStatus {
+            branch: "main".to_string(),
+        };
+        mock.expect_get_status()
+            .withf(|p| p == Path::new("/tmp/repo"))
+            .returning(|_| {
+                Ok(GitStatus {
+                    branch: "main".to_string(),
+                })
+            });
+
+        let service = GitService::new(mock);
+        let path = PathBuf::from("/tmp/repo");
+        let status = service.get_status(&path).await.unwrap();
+        assert_eq!(status.branch, expected.branch);
+    }
+}

--- a/crates/mm-git/src/status.rs
+++ b/crates/mm-git/src/status.rs
@@ -1,0 +1,9 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Represents the status of a Git repository
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub struct GitStatus {
+    /// Current branch name
+    pub branch: String,
+}

--- a/crates/mm-server/src/mcp/create_task.rs
+++ b/crates/mm-server/src/mcp/create_task.rs
@@ -22,6 +22,9 @@ pub struct CreateTaskTool {
     pub properties: Option<TaskProperties>,
     /// Project to associate with
     pub project_name: Option<String>,
+    /// Tasks that this task depends on
+    #[serde(default)]
+    pub depends_on: Vec<String>,
 }
 
 impl CreateTaskTool {
@@ -35,7 +38,8 @@ impl CreateTaskTool {
                 properties: self.properties.clone().unwrap_or_default(),
                 relationships: Vec::new(),
             },
-            project_name
+            project_name,
+            depends_on
         },
         create_task,
         |command, _result| {
@@ -51,18 +55,106 @@ impl CreateTaskTool {
 mod tests {
     use super::*;
     use mm_core::Ports;
-    use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
+    use mm_memory::{MemoryConfig, MemoryEntity, MemoryService, MockMemoryRepository};
+    use mockall::predicate::*;
+    use std::collections::HashSet;
     use std::sync::Arc;
 
     #[tokio::test]
     async fn test_call_tool_success() {
         let mut mock = MockMemoryRepository::new();
+
+        mock.expect_find_entity_by_name()
+            .with(eq("task:dep"))
+            .returning(|_| Ok(Some(MemoryEntity::default())));
         mock.expect_create_entities()
             .withf(|ents| ents.len() == 1 && ents[0].name == "task:1")
             .returning(|_| Ok(()));
         mock.expect_create_relationships()
             .withf(|rels| rels.len() == 1 && rels[0].from == "proj" && rels[0].to == "task:1")
             .returning(|_| Ok(()));
+
+        let service = MemoryService::new(
+            mock,
+            MemoryConfig {
+                default_project: Some("proj".into()),
+                additional_relationships: std::iter::once("depends_on".to_string())
+                    .collect::<HashSet<_>>(),
+                ..MemoryConfig::default()
+            },
+        );
+        let ports = Ports::new(Arc::new(service));
+
+        let tool = CreateTaskTool {
+            task_name: "task:1".into(),
+            labels: vec!["Task".into()],
+            observations: vec![],
+            properties: None,
+            project_name: None,
+            depends_on: Vec::new(),
+        };
+
+        let result = tool.call_tool(&ports).await.unwrap();
+        let text = result.content[0].as_text_content().unwrap().text.clone();
+        assert_eq!(text, "task:1");
+    }
+
+    #[tokio::test]
+    async fn test_call_tool_with_dependencies() {
+        let mut mock = MockMemoryRepository::new();
+
+        mock.expect_find_entity_by_name()
+            .with(eq("task:dep"))
+            .returning(|_| Ok(Some(MemoryEntity::default())));
+
+        mock.expect_create_entities()
+            .withf(|ents| ents.len() == 1 && ents[0].name == "task:1")
+            .returning(|_| Ok(()));
+
+        mock.expect_create_relationships()
+            .withf(|rels| {
+                rels.len() == 2
+                    && rels[0].name == "contains"
+                    && rels[1].name == "depends_on"
+                    && rels[1].to == "task:dep"
+                    && rels[1].from == "task:1"
+            })
+            .returning(|_| Ok(()));
+
+        let service = MemoryService::new(
+            mock,
+            MemoryConfig {
+                default_project: Some("proj".into()),
+                additional_relationships: std::iter::once("depends_on".to_string())
+                    .collect::<HashSet<_>>(),
+                ..MemoryConfig::default()
+            },
+        );
+        let ports = Ports::new(Arc::new(service));
+
+        let tool = CreateTaskTool {
+            task_name: "task:1".into(),
+            labels: vec!["Task".into()],
+            observations: vec![],
+            properties: None,
+            project_name: None,
+            depends_on: vec!["task:dep".into()],
+        };
+
+        let result = tool.call_tool(&ports).await.unwrap();
+        let text = result.content[0].as_text_content().unwrap().text.clone();
+        assert_eq!(text, "task:1");
+    }
+
+    #[tokio::test]
+    async fn test_call_tool_dependency_missing() {
+        let mut mock = MockMemoryRepository::new();
+
+        mock.expect_find_entity_by_name()
+            .with(eq("missing"))
+            .returning(|_| Ok(None));
+        mock.expect_create_entities().never();
+        mock.expect_create_relationships().never();
 
         let service = MemoryService::new(
             mock,
@@ -79,10 +171,42 @@ mod tests {
             observations: vec![],
             properties: None,
             project_name: None,
+            depends_on: vec!["missing".into()],
         };
 
-        let result = tool.call_tool(&ports).await.unwrap();
-        let text = result.content[0].as_text_content().unwrap().text.clone();
-        assert_eq!(text, "task:1");
+        let result = tool.call_tool(&ports).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_call_tool_self_dependency() {
+        let mut mock = MockMemoryRepository::new();
+
+        mock.expect_create_entities().never();
+        mock.expect_create_relationships().never();
+        mock.expect_find_entity_by_name().never();
+
+        let service = MemoryService::new(
+            mock,
+            MemoryConfig {
+                default_project: Some("proj".into()),
+                additional_relationships: std::iter::once("depends_on".to_string())
+                    .collect::<HashSet<_>>(),
+                ..MemoryConfig::default()
+            },
+        );
+        let ports = Ports::new(Arc::new(service));
+
+        let tool = CreateTaskTool {
+            task_name: "task:1".into(),
+            labels: vec!["Task".into()],
+            observations: vec![],
+            properties: None,
+            project_name: None,
+            depends_on: vec!["task:1".into()],
+        };
+
+        let result = tool.call_tool(&ports).await;
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Summary
- prevent tasks from depending on themselves
- validate dependencies concurrently using `try_join_all`
- add `futures` dependency in `mm-core`
- extend unit tests for self dependency handling

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_685b1adfa00c8327944968d22b4a1fa4