### PR TITLE
Refactor task operations via generic helpers

### DIFF
--- a/crates/mm-core/src/operations/memory/generic.rs
+++ b/crates/mm-core/src/operations/memory/generic.rs
@@ -1,0 +1,59 @@
+use crate::error::{CoreError, CoreResult};
+use crate::ports::Ports;
+use crate::validate_name;
+use mm_git::GitRepository;
+use mm_memory::{EntityUpdate, MemoryEntity, MemoryRepository, value::MemoryValue};
+use schemars::JsonSchema;
+use std::collections::HashMap;
+use tracing::instrument;
+
+pub type UpdateEntityGenericResult<E> = CoreResult<(), E>;
+
+#[instrument(skip(ports), fields(name = %name))]
+pub async fn update_entity_generic<M, G>(
+    ports: &Ports<M, G>,
+    name: &str,
+    update: &EntityUpdate,
+) -> UpdateEntityGenericResult<M::Error>
+where
+    M: MemoryRepository + Send + Sync,
+    G: GitRepository + Send + Sync,
+    M::Error: std::error::Error + Send + Sync + 'static,
+    G::Error: std::error::Error + Send + Sync + 'static,
+{
+    validate_name!(name);
+
+    ports
+        .memory_service
+        .update_entity(name, update)
+        .await
+        .map_err(CoreError::from)
+}
+
+pub type GetEntityGenericResult<P, E> = CoreResult<Option<MemoryEntity<P>>, E>;
+
+#[instrument(skip(ports), fields(name = %name))]
+pub async fn get_entity_generic<M, G, P>(
+    ports: &Ports<M, G>,
+    name: &str,
+) -> GetEntityGenericResult<P, M::Error>
+where
+    M: MemoryRepository + Send + Sync,
+    G: GitRepository + Send + Sync,
+    M::Error: std::error::Error + Send + Sync + 'static,
+    G::Error: std::error::Error + Send + Sync + 'static,
+    P: JsonSchema
+        + From<HashMap<String, MemoryValue>>
+        + Into<HashMap<String, MemoryValue>>
+        + Clone
+        + std::fmt::Debug
+        + Default,
+{
+    validate_name!(name);
+
+    ports
+        .memory_service
+        .find_entity_by_name_typed::<P>(name)
+        .await
+        .map_err(CoreError::from)
+}

--- a/crates/mm-core/src/operations/memory/get_entity.rs
+++ b/crates/mm-core/src/operations/memory/get_entity.rs
@@ -1,6 +1,8 @@
-use crate::error::{CoreError, CoreResult};
+#[cfg(test)]
+use crate::error::CoreError;
+use crate::error::CoreResult;
+use crate::operations::memory::generic::get_entity_generic;
 use crate::ports::Ports;
-use crate::validate_name;
 use mm_git::GitRepository;
 use mm_memory::MemoryEntity;
 use mm_memory::MemoryRepository;
@@ -37,15 +39,11 @@ where
     M::Error: std::error::Error + Send + Sync + 'static,
     G::Error: std::error::Error + Send + Sync + 'static,
 {
-    // Validate command
-    validate_name!(command.name);
-
-    // Find entity using the memory service
-    ports
-        .memory_service
-        .find_entity_by_name(&command.name)
-        .await
-        .map_err(CoreError::from)
+    get_entity_generic::<M, G, std::collections::HashMap<String, mm_memory::value::MemoryValue>>(
+        ports,
+        &command.name,
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/crates/mm-core/src/operations/memory/mod.rs
+++ b/crates/mm-core/src/operations/memory/mod.rs
@@ -1,4 +1,5 @@
 mod common;
+mod generic;
 mod git;
 mod tasks;
 
@@ -30,6 +31,7 @@ pub use find_relationships::{
     FindRelationshipsCommand, FindRelationshipsResult, FindRelationshipsResultType,
     find_relationships,
 };
+pub use generic::{get_entity_generic, update_entity_generic};
 pub use get_entity::{GetEntityCommand, GetEntityResult, get_entity};
 pub use get_project_context::{
     GetProjectContextCommand, GetProjectContextResult, ProjectFilter, get_project_context,

--- a/crates/mm-core/src/operations/memory/tasks/delete_task.rs
+++ b/crates/mm-core/src/operations/memory/tasks/delete_task.rs
@@ -1,4 +1,7 @@
-use crate::error::{CoreError, CoreResult};
+#[cfg(test)]
+use crate::error::CoreError;
+use crate::error::CoreResult;
+use crate::operations::memory::{DeleteEntitiesCommand, delete_entities};
 use crate::ports::Ports;
 use crate::validate_name;
 use mm_git::GitRepository;
@@ -25,17 +28,13 @@ where
 {
     validate_name!(command.name);
 
-    let errors = ports
-        .memory_service
-        .delete_entities(std::slice::from_ref(&command.name))
-        .await
-        .map_err(CoreError::from)?;
-
-    if !errors.is_empty() {
-        return Err(CoreError::BatchValidation(errors));
-    }
-
-    Ok(())
+    delete_entities(
+        ports,
+        DeleteEntitiesCommand {
+            names: vec![command.name],
+        },
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/crates/mm-core/src/operations/memory/tasks/get_task.rs
+++ b/crates/mm-core/src/operations/memory/tasks/get_task.rs
@@ -1,7 +1,9 @@
 use super::types::TaskProperties;
-use crate::error::{CoreError, CoreResult};
+#[cfg(test)]
+use crate::error::CoreError;
+use crate::error::CoreResult;
+use crate::operations::memory::generic::get_entity_generic;
 use crate::ports::Ports;
-use crate::validate_name;
 use mm_git::GitRepository;
 use mm_memory::{MemoryEntity, MemoryRepository};
 use tracing::instrument;
@@ -21,13 +23,7 @@ where
     M::Error: std::error::Error + Send + Sync + 'static,
     G::Error: std::error::Error + Send + Sync + 'static,
 {
-    validate_name!(command.name);
-
-    ports
-        .memory_service
-        .find_entity_by_name_typed::<TaskProperties>(&command.name)
-        .await
-        .map_err(CoreError::from)
+    get_entity_generic::<M, G, TaskProperties>(ports, &command.name).await
 }
 
 #[cfg(test)]

--- a/crates/mm-core/src/operations/memory/tasks/update_task.rs
+++ b/crates/mm-core/src/operations/memory/tasks/update_task.rs
@@ -1,6 +1,8 @@
-use crate::error::{CoreError, CoreResult};
+#[cfg(test)]
+use crate::error::CoreError;
+use crate::error::CoreResult;
+use crate::operations::memory::generic::update_entity_generic;
 use crate::ports::Ports;
-use crate::validate_name;
 use mm_git::GitRepository;
 use mm_memory::{EntityUpdate, MemoryRepository};
 use tracing::instrument;
@@ -24,13 +26,7 @@ where
     M::Error: std::error::Error + Send + Sync + 'static,
     G::Error: std::error::Error + Send + Sync + 'static,
 {
-    validate_name!(command.name);
-
-    ports
-        .memory_service
-        .update_entity(&command.name, &command.update)
-        .await
-        .map_err(CoreError::from)
+    update_entity_generic(ports, &command.name, &command.update).await
 }
 
 #[cfg(test)]

--- a/crates/mm-core/src/operations/memory/update_entity.rs
+++ b/crates/mm-core/src/operations/memory/update_entity.rs
@@ -1,6 +1,8 @@
-use crate::error::{CoreError, CoreResult};
+#[cfg(test)]
+use crate::error::CoreError;
+use crate::error::CoreResult;
+use crate::operations::memory::generic::update_entity_generic;
 use crate::ports::Ports;
-use crate::validate_name;
 use mm_git::GitRepository;
 use mm_memory::{EntityUpdate, MemoryRepository};
 use tracing::instrument;
@@ -24,13 +26,7 @@ where
     M::Error: std::error::Error + Send + Sync + 'static,
     G::Error: std::error::Error + Send + Sync + 'static,
 {
-    validate_name!(command.name);
-
-    ports
-        .memory_service
-        .update_entity(&command.name, &command.update)
-        .await
-        .map_err(CoreError::from)
+    update_entity_generic(ports, &command.name, &command.update).await
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- add `get_entity_generic` and `update_entity_generic` helpers
- expose these helpers in the memory operations module
- refactor task operations to use the new helpers
- keep delete_task behavior by delegating to `delete_entities`

## Testing
- `just validate`


------
https://chatgpt.com/codex/tasks/task_e_685b7e453cf4832790c00ff04c71bf29