### PR TITLE
Add batch result helper

### DIFF
--- a/crates/mm-core/src/operations/memory/common.rs
+++ b/crates/mm-core/src/operations/memory/common.rs
@@ -8,3 +8,26 @@ macro_rules! validate_name {
         }
     };
 }
+
+use crate::error::{CoreError, CoreResult};
+use mm_memory::{MemoryError, ValidationError};
+
+/// Handle the result of a batch memory service call.
+///
+/// This utility executes a future returned by `MemoryService` methods that
+/// produce a list of `(name, ValidationError)` tuples on success. If the list
+/// is empty the operation succeeded, otherwise a `CoreError::BatchValidation`
+/// is returned.
+pub async fn handle_batch_result<F, Fut, E>(fut: F) -> CoreResult<(), E>
+where
+    Fut: std::future::Future<Output = Result<Vec<(String, ValidationError)>, MemoryError<E>>>,
+    F: FnOnce() -> Fut,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    let errors = fut().await.map_err(CoreError::from)?;
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(CoreError::BatchValidation(errors))
+    }
+}

--- a/crates/mm-core/src/operations/memory/create_entity.rs
+++ b/crates/mm-core/src/operations/memory/create_entity.rs
@@ -1,4 +1,5 @@
-use crate::error::{CoreError, CoreResult};
+use super::common::handle_batch_result;
+use crate::error::CoreResult;
 use crate::ports::Ports;
 use mm_git::GitRepository;
 use mm_memory::MemoryEntity;
@@ -35,22 +36,13 @@ where
     M::Error: std::error::Error + Send + Sync + 'static,
     G::Error: std::error::Error + Send + Sync + 'static,
 {
-    let errors = ports
-        .memory_service
-        .create_entities(&command.entities)
-        .await
-        .map_err(CoreError::from)?;
-
-    if !errors.is_empty() {
-        return Err(CoreError::BatchValidation(errors));
-    }
-
-    Ok(())
+    handle_batch_result(|| ports.memory_service.create_entities(&command.entities)).await
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::CoreError;
     use mm_git::repository::MockGitRepository;
     use mm_memory::ValidationErrorKind;
     use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};

--- a/crates/mm-core/src/operations/memory/create_relationship.rs
+++ b/crates/mm-core/src/operations/memory/create_relationship.rs
@@ -1,4 +1,5 @@
-use crate::error::{CoreError, CoreResult};
+use super::common::handle_batch_result;
+use crate::error::CoreResult;
 use crate::ports::Ports;
 use mm_git::GitRepository;
 use mm_memory::{MemoryRelationship, MemoryRepository};
@@ -22,22 +23,18 @@ where
     M::Error: std::error::Error + Send + Sync + 'static,
     G::Error: std::error::Error + Send + Sync + 'static,
 {
-    let errors = ports
-        .memory_service
-        .create_relationships(&command.relationships)
-        .await
-        .map_err(CoreError::from)?;
-
-    if !errors.is_empty() {
-        return Err(CoreError::BatchValidation(errors));
-    }
-
-    Ok(())
+    handle_batch_result(|| {
+        ports
+            .memory_service
+            .create_relationships(&command.relationships)
+    })
+    .await
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::CoreError;
     use mm_git::repository::MockGitRepository;
     use mm_memory::ValidationErrorKind;
     use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};

--- a/crates/mm-core/src/operations/memory/delete_entities.rs
+++ b/crates/mm-core/src/operations/memory/delete_entities.rs
@@ -1,4 +1,5 @@
-use crate::error::{CoreError, CoreResult};
+use super::common::handle_batch_result;
+use crate::error::CoreResult;
 use crate::ports::Ports;
 use mm_git::GitRepository;
 use mm_memory::MemoryRepository;
@@ -22,15 +23,5 @@ where
     M::Error: std::error::Error + Send + Sync + 'static,
     G::Error: std::error::Error + Send + Sync + 'static,
 {
-    let errors = ports
-        .memory_service
-        .delete_entities(&command.names)
-        .await
-        .map_err(CoreError::from)?;
-
-    if !errors.is_empty() {
-        return Err(CoreError::BatchValidation(errors));
-    }
-
-    Ok(())
+    handle_batch_result(|| ports.memory_service.delete_entities(&command.names)).await
 }

--- a/crates/mm-core/src/operations/memory/delete_relationships.rs
+++ b/crates/mm-core/src/operations/memory/delete_relationships.rs
@@ -1,4 +1,5 @@
-use crate::error::{CoreError, CoreResult};
+use super::common::handle_batch_result;
+use crate::error::CoreResult;
 use crate::ports::Ports;
 use mm_git::GitRepository;
 use mm_memory::{MemoryRepository, relationship::RelationshipRef};
@@ -22,15 +23,10 @@ where
     M::Error: std::error::Error + Send + Sync + 'static,
     G::Error: std::error::Error + Send + Sync + 'static,
 {
-    let errors = ports
-        .memory_service
-        .delete_relationships(&command.relationships)
-        .await
-        .map_err(CoreError::from)?;
-
-    if !errors.is_empty() {
-        return Err(CoreError::BatchValidation(errors));
-    }
-
-    Ok(())
+    handle_batch_result(|| {
+        ports
+            .memory_service
+            .delete_relationships(&command.relationships)
+    })
+    .await
 }

--- a/crates/mm-core/src/operations/memory/tasks/create_tasks.rs
+++ b/crates/mm-core/src/operations/memory/tasks/create_tasks.rs
@@ -1,3 +1,4 @@
+use super::super::common::handle_batch_result;
 use super::types::TaskProperties;
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
@@ -39,15 +40,7 @@ where
     let task_names: Vec<String> = tasks.iter().map(|t| t.name.clone()).collect();
 
     // Create the task entity
-    let errors = ports
-        .memory_service
-        .create_entities_typed(&tasks)
-        .await
-        .map_err(CoreError::from)?;
-
-    if !errors.is_empty() {
-        return Err(CoreError::BatchValidation(errors));
-    }
+    handle_batch_result(|| ports.memory_service.create_entities_typed(&tasks)).await?;
 
     let relationships: Vec<MemoryRelationship> = task_names
         .into_iter()
@@ -59,15 +52,7 @@ where
         })
         .collect();
 
-    let errors = ports
-        .memory_service
-        .create_relationships(&relationships)
-        .await
-        .map_err(CoreError::from)?;
-
-    if !errors.is_empty() {
-        return Err(CoreError::BatchValidation(errors));
-    }
+    handle_batch_result(|| ports.memory_service.create_relationships(&relationships)).await?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- consolidate batch error handling in memory ops
- use the helper across create/delete operations

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_685b82b9535c8327a3c840090d565e14