### PR TITLE
Add helper for conflict checks

### DIFF
--- a/crates/mm-memory/src/service.rs
+++ b/crates/mm-memory/src/service.rs
@@ -57,34 +57,26 @@ trait UpdateOps {
     fn has_set(&self) -> bool;
 }
 
-impl UpdateOps for ObservationsUpdate {
-    fn has_add(&self) -> bool {
-        self.add.is_some()
-    }
+macro_rules! impl_update_ops {
+    ($type:ty) => {
+        impl UpdateOps for $type {
+            fn has_add(&self) -> bool {
+                self.add.is_some()
+            }
 
-    fn has_remove(&self) -> bool {
-        self.remove.is_some()
-    }
+            fn has_remove(&self) -> bool {
+                self.remove.is_some()
+            }
 
-    fn has_set(&self) -> bool {
-        self.set.is_some()
-    }
+            fn has_set(&self) -> bool {
+                self.set.is_some()
+            }
+        }
+    };
 }
 
-impl UpdateOps for PropertiesUpdate {
-    fn has_add(&self) -> bool {
-        self.add.is_some()
-    }
-
-    fn has_remove(&self) -> bool {
-        self.remove.is_some()
-    }
-
-    fn has_set(&self) -> bool {
-        self.set.is_some()
-    }
-}
-
+impl_update_ops!(ObservationsUpdate);
+impl_update_ops!(PropertiesUpdate);
 fn ensure_no_conflicting_ops<U: UpdateOps>(
     ops: &U,
     field: &'static str,


### PR DESCRIPTION
## Summary
- add trait-based `ensure_no_conflicting_ops` for update validation
- allow add/remove together without `set`
- update tests for new semantics

## Testing
- `just validate`


------
https://chatgpt.com/codex/tasks/task_e_685b831341b88327ae19b7a46b455338