### PR TITLE
Add execute method for MMTools

### DIFF
--- a/crates/mm-server/src/lib.rs
+++ b/crates/mm-server/src/lib.rs
@@ -177,30 +177,7 @@ where
         let tool_params = MMTools::try_from(request.params)
             .map_err(|_| CallToolError::unknown_tool(tool_name.clone()))?;
 
-        // Match the tool variant and execute its corresponding logic
-        let result = match tool_params {
-            MMTools::CreateEntitiesTool(create_entity_tool) => {
-                create_entity_tool.call_tool(&self.ports).await?
-            }
-            MMTools::CreateRelationshipsTool(tool) => tool.call_tool(&self.ports).await?,
-            MMTools::DeleteEntitiesTool(tool) => tool.call_tool(&self.ports).await?,
-            MMTools::DeleteRelationshipsTool(tool) => tool.call_tool(&self.ports).await?,
-            MMTools::FindEntitiesByLabelsTool(tool) => tool.call_tool(&self.ports).await?,
-            MMTools::FindRelationshipsTool(tool) => tool.call_tool(&self.ports).await?,
-            MMTools::CreateTasksTool(tool) => tool.call_tool(&self.ports).await?,
-            MMTools::GetTaskTool(tool) => tool.call_tool(&self.ports).await?,
-            MMTools::UpdateTaskTool(tool) => tool.call_tool(&self.ports).await?,
-            MMTools::DeleteTaskTool(tool) => tool.call_tool(&self.ports).await?,
-            MMTools::GetEntityTool(get_entity_tool) => {
-                get_entity_tool.call_tool(&self.ports).await?
-            }
-            MMTools::GetGitStatusTool(tool) => tool.call_tool(&self.ports).await?,
-            MMTools::GetProjectContextTool(tool) => tool.call_tool(&self.ports).await?,
-            MMTools::ListProjectsTool(tool) => tool.call_tool(&self.ports).await?,
-            MMTools::UpdateEntityTool(tool) => tool.call_tool(&self.ports).await?,
-            MMTools::UpdateRelationshipTool(tool) => tool.call_tool(&self.ports).await?,
-        };
-        Ok(result)
+        tool_params.execute(&self.ports).await
     }
 }
 
@@ -379,25 +356,10 @@ pub async fn run_tools<P: AsRef<Path>>(command: ToolsCommand, config_paths: &[P]
                 };
                 let tool =
                     MMTools::try_from(params).map_err(|e| anyhow::anyhow!(format!("{e:?}")))?;
-                let result = match tool {
-                    MMTools::CreateEntitiesTool(t) => t.call_tool(&ports).await,
-                    MMTools::CreateRelationshipsTool(t) => t.call_tool(&ports).await,
-                    MMTools::DeleteEntitiesTool(t) => t.call_tool(&ports).await,
-                    MMTools::DeleteRelationshipsTool(t) => t.call_tool(&ports).await,
-                    MMTools::FindEntitiesByLabelsTool(t) => t.call_tool(&ports).await,
-                    MMTools::FindRelationshipsTool(t) => t.call_tool(&ports).await,
-                    MMTools::CreateTasksTool(t) => t.call_tool(&ports).await,
-                    MMTools::GetTaskTool(t) => t.call_tool(&ports).await,
-                    MMTools::UpdateTaskTool(t) => t.call_tool(&ports).await,
-                    MMTools::DeleteTaskTool(t) => t.call_tool(&ports).await,
-                    MMTools::GetEntityTool(t) => t.call_tool(&ports).await,
-                    MMTools::GetGitStatusTool(t) => t.call_tool(&ports).await,
-                    MMTools::GetProjectContextTool(t) => t.call_tool(&ports).await,
-                    MMTools::ListProjectsTool(t) => t.call_tool(&ports).await,
-                    MMTools::UpdateEntityTool(t) => t.call_tool(&ports).await,
-                    MMTools::UpdateRelationshipTool(t) => t.call_tool(&ports).await,
-                }
-                .map_err(|e| anyhow::anyhow!(format!("{e:?}")))?;
+                let result = tool
+                    .execute(&ports)
+                    .await
+                    .map_err(|e| anyhow::anyhow!(format!("{e:?}")))?;
                 println!("{}", serde_json::to_string_pretty(&result)?);
             }
         },

--- a/crates/mm-server/src/mcp/mod.rs
+++ b/crates/mm-server/src/mcp/mod.rs
@@ -59,3 +59,39 @@ tool_box!(
         UpdateRelationshipTool
     ]
 );
+
+impl MMTools {
+    /// Execute the contained tool using the provided ports.
+    pub async fn execute<M, G>(
+        self,
+        ports: &mm_core::Ports<M, G>,
+    ) -> Result<
+        rust_mcp_sdk::schema::CallToolResult,
+        rust_mcp_sdk::schema::schema_utils::CallToolError,
+    >
+    where
+        M: mm_memory::MemoryRepository + Send + Sync,
+        G: mm_git::GitRepository + Send + Sync,
+        M::Error: std::error::Error + Send + Sync + 'static,
+        G::Error: std::error::Error + Send + Sync + 'static,
+    {
+        match self {
+            MMTools::CreateEntitiesTool(tool) => tool.call_tool(ports).await,
+            MMTools::CreateRelationshipsTool(tool) => tool.call_tool(ports).await,
+            MMTools::DeleteEntitiesTool(tool) => tool.call_tool(ports).await,
+            MMTools::DeleteRelationshipsTool(tool) => tool.call_tool(ports).await,
+            MMTools::FindEntitiesByLabelsTool(tool) => tool.call_tool(ports).await,
+            MMTools::FindRelationshipsTool(tool) => tool.call_tool(ports).await,
+            MMTools::CreateTasksTool(tool) => tool.call_tool(ports).await,
+            MMTools::GetTaskTool(tool) => tool.call_tool(ports).await,
+            MMTools::UpdateTaskTool(tool) => tool.call_tool(ports).await,
+            MMTools::DeleteTaskTool(tool) => tool.call_tool(ports).await,
+            MMTools::GetEntityTool(tool) => tool.call_tool(ports).await,
+            MMTools::GetGitStatusTool(tool) => tool.call_tool(ports).await,
+            MMTools::GetProjectContextTool(tool) => tool.call_tool(ports).await,
+            MMTools::ListProjectsTool(tool) => tool.call_tool(ports).await,
+            MMTools::UpdateEntityTool(tool) => tool.call_tool(ports).await,
+            MMTools::UpdateRelationshipTool(tool) => tool.call_tool(ports).await,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add an `execute` helper on `MMTools` to run the contained tool
- use the new helper inside the server handler and CLI

## Testing
- `just validate`


------
https://chatgpt.com/codex/tasks/task_e_685b91515d6c8327894d6ca5a11de4ae