### PR TITLE
Keep explicit macro imports for validate_name

### DIFF
--- a/crates/mm-core/src/lib.rs
+++ b/crates/mm-core/src/lib.rs
@@ -15,6 +15,8 @@ pub use error::{CoreError, CoreResult};
 pub use ports::Ports;
 pub use root::{Root, RootCollection};
 
+pub(crate) use operations::memory::validate_name;
+
 // Re-export the mm-memory crate for easy access to memory types and services
 pub use mm_memory;
 

--- a/crates/mm-core/src/operations/memory/common.rs
+++ b/crates/mm-core/src/operations/memory/common.rs
@@ -1,4 +1,3 @@
-#[macro_export]
 macro_rules! validate_name {
     ($name:expr) => {
         if $name.is_empty() {

--- a/crates/mm-core/src/operations/memory/mod.rs
+++ b/crates/mm-core/src/operations/memory/mod.rs
@@ -1,7 +1,10 @@
+#[macro_use]
 mod common;
 mod generic;
 mod git;
 mod tasks;
+
+pub(crate) use validate_name;
 
 pub mod create_entity;
 pub mod create_relationship;


### PR DESCRIPTION
## Summary
- re-export `validate_name!` only inside the crate
- keep explicit `use crate::validate_name` in memory modules

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_685b8664c0448327bb1aa56e75b55be3