### PR TITLE
Switch Ports to tokio::RwLock

### DIFF
--- a/crates/mm-core/Cargo.toml
+++ b/crates/mm-core/Cargo.toml
@@ -18,6 +18,7 @@ async-trait = { workspace = true }
 schemars = { workspace = true }
 chrono = { workspace = true }
 futures = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 
 [dev-dependencies]
 mockall = { workspace = true }

--- a/crates/mm-core/src/ports.rs
+++ b/crates/mm-core/src/ports.rs
@@ -1,6 +1,7 @@
 use mm_git::{GitRepository, GitService};
 use mm_memory::{MemoryRepository, MemoryService};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 
 use crate::RootCollection;
 

--- a/crates/mm-server/src/lib.rs
+++ b/crates/mm-server/src/lib.rs
@@ -97,14 +97,8 @@ where
                         .into_iter()
                         .map(roots::from_sdk_root)
                         .collect::<Vec<_>>();
-                    match self.ports.roots.write() {
-                        Ok(mut collection) => {
-                            collection.set_roots(roots);
-                        }
-                        Err(err) => {
-                            error!("Failed to acquire write lock on roots: {err}");
-                        }
-                    }
+                    let mut collection = self.ports.roots.write().await;
+                    collection.set_roots(roots);
                 }
                 Err(err) => {
                     error!("Failed to list client roots and update the roots collection: {err}");


### PR DESCRIPTION
## Summary
- use `tokio::sync::RwLock` in `Ports`
- update constructors and noop helper
- adjust server handler to await write guard

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_685b92c32c50832787c966f63fe5d022