### PR TITLE
Refactor panic calls in tests

### DIFF
--- a/crates/mm-core/src/operations/git/status.rs
+++ b/crates/mm-core/src/operations/git/status.rs
@@ -81,10 +81,9 @@ mod tests {
         let result = get_git_status(&ports, command).await;
 
         // Assert the result
-        assert!(result.is_err());
-        match result {
-            Err(CoreError::Git(_)) => {}
-            _ => panic!("Expected Git error"),
-        }
+        assert!(
+            matches!(result, Err(CoreError::Git(_))),
+            "Expected Git error"
+        );
     }
 }

--- a/crates/mm-core/src/operations/memory/create_entity.rs
+++ b/crates/mm-core/src/operations/memory/create_entity.rs
@@ -196,7 +196,7 @@ mod tests {
                         .contains(&ValidationErrorKind::NoLabels("valid:entity".to_string()))
             }));
         } else {
-            panic!("Expected batch validation error");
+            unreachable!("Expected batch validation error");
         }
     }
 }

--- a/crates/mm-core/src/operations/memory/create_relationship.rs
+++ b/crates/mm-core/src/operations/memory/create_relationship.rs
@@ -185,7 +185,7 @@ mod tests {
                         .contains(&ValidationErrorKind::UnknownRelationship("".to_string()))
             }));
         } else {
-            panic!("Expected batch validation error");
+            unreachable!("Expected batch validation error");
         }
     }
 }


### PR DESCRIPTION
## Summary
- refactor tests in `mm-core` to avoid `panic!`
- use `assert!` and `unreachable!` macros for clearer intent

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_685b96872e9c83279b30d6c82fb82a67