### PR TITLE
Optimize observation updates in Neo4j repository

### DIFF
--- a/crates/mm-memory-neo4j/src/adapters/neo4j/repository.rs
+++ b/crates/mm-memory-neo4j/src/adapters/neo4j/repository.rs
@@ -262,7 +262,7 @@ impl MemoryRepository for Neo4jRepository {
         observations: &[String],
     ) -> MemoryResult<(), Self::Error> {
         let query = Query::new(
-            "MATCH (n {name: $name}) SET n.observations = [o IN n.observations WHERE NOT o IN $remove]"
+            "MATCH (n {name: $name}) SET n.observations = [o IN coalesce(n.observations, []) WHERE NOT o IN $remove]"
                 .to_string(),
         )
         .param("name", name.to_string())


### PR DESCRIPTION
## Summary
- update Neo4j `add_observations` and `remove_observations` to perform a single Cypher query using list operations
- remove redundant `find_entity_by_name` calls

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_685b97c152f083278c965be288f48f50