### PR TITLE
Add schema helper for MCP tests

### DIFF
--- a/crates/mm-server/src/mcp/create_entities.rs
+++ b/crates/mm-server/src/mcp/create_entities.rs
@@ -86,31 +86,10 @@ mod tests {
 #[cfg(test)]
 mod schema_tests {
     use super::*;
-    use mm_utils::IntoJsonSchema;
+    use crate::mcp::tests::assert_no_defs;
 
     #[test]
     fn test_schema_has_no_refs() {
-        // Generate the schema for CreateEntityTool
-        let schema = CreateEntitiesTool::json_schema();
-
-        // Convert to a Value for easier inspection
-        let schema_value =
-            serde_json::to_value(&schema).expect("Failed to convert schema to Value");
-
-        // Convert to a string to check for $defs
-        let schema_str =
-            serde_json::to_string(&schema_value).expect("Failed to convert schema to string");
-
-        // Verify that the schema doesn't contain $defs
-        assert!(
-            !schema_str.contains("\"$defs\""),
-            "Schema should not contain $defs section"
-        );
-
-        // Verify that the schema doesn't contain any $ref that points to $defs
-        assert!(
-            !schema_str.contains("\"$ref\":\"#/$defs/"),
-            "Schema should not contain references to $defs"
-        );
+        assert_no_defs::<CreateEntitiesTool>();
     }
 }

--- a/crates/mm-server/src/mcp/create_relationships.rs
+++ b/crates/mm-server/src/mcp/create_relationships.rs
@@ -106,27 +106,10 @@ mod tests {
 #[cfg(test)]
 mod schema_tests {
     use super::*;
-    use mm_utils::IntoJsonSchema;
+    use crate::mcp::tests::assert_no_defs;
 
     #[test]
     fn test_schema_has_no_refs() {
-        // Generate the schema for CreateRelationshipTool
-        let schema = CreateRelationshipsTool::json_schema();
-
-        // Convert to a string to check for $defs
-        let schema_str =
-            serde_json::to_string(&schema).expect("Failed to convert schema to string");
-
-        // Verify that the schema doesn't contain $defs
-        assert!(
-            !schema_str.contains("\"$defs\""),
-            "Schema should not contain $defs section"
-        );
-
-        // Verify that the schema doesn't contain any $ref that points to $defs
-        assert!(
-            !schema_str.contains("\"$ref\":\"#/$defs/"),
-            "Schema should not contain references to $defs"
-        );
+        assert_no_defs::<CreateRelationshipsTool>();
     }
 }

--- a/crates/mm-server/src/mcp/mod.rs
+++ b/crates/mm-server/src/mcp/mod.rs
@@ -14,6 +14,8 @@ pub mod get_git_status;
 pub mod get_project_context;
 pub mod get_task;
 pub mod list_projects;
+#[cfg(test)]
+pub mod tests;
 pub mod update_entity;
 pub mod update_relationship;
 pub mod update_task;

--- a/crates/mm-server/src/mcp/tests/mod.rs
+++ b/crates/mm-server/src/mcp/tests/mod.rs
@@ -2,11 +2,11 @@
 
 pub fn assert_no_defs<T: mm_utils::IntoJsonSchema>() {
     let schema = T::json_schema();
-    let schema_str = serde_json::to_string(&schema).expect("Failed to convert schema to string");
     assert!(
-        !schema_str.contains("\"$defs\""),
+        !schema.contains_key("$defs"),
         "Schema should not contain $defs section",
     );
+    let schema_str = serde_json::to_string(&schema).expect("Failed to convert schema to string");
     assert!(
         !schema_str.contains("\"$ref\":\"#/$defs/"),
         "Schema should not contain references to $defs",

--- a/crates/mm-server/src/mcp/tests/mod.rs
+++ b/crates/mm-server/src/mcp/tests/mod.rs
@@ -1,0 +1,14 @@
+#![cfg(test)]
+
+pub fn assert_no_defs<T: mm_utils::IntoJsonSchema>() {
+    let schema = T::json_schema();
+    let schema_str = serde_json::to_string(&schema).expect("Failed to convert schema to string");
+    assert!(
+        !schema_str.contains("\"$defs\""),
+        "Schema should not contain $defs section",
+    );
+    assert!(
+        !schema_str.contains("\"$ref\":\"#/$defs/"),
+        "Schema should not contain references to $defs",
+    );
+}

--- a/crates/mm-server/src/mcp/tests/mod.rs
+++ b/crates/mm-server/src/mcp/tests/mod.rs
@@ -1,5 +1,3 @@
-#![cfg(test)]
-
 pub fn assert_no_defs<T: mm_utils::IntoJsonSchema>() {
     let schema = T::json_schema();
     assert!(


### PR DESCRIPTION
## Summary
- add a shared `assert_no_defs` helper under `mcp/tests`
- expose test utilities module in `mcp::mod`
- use helper in `create_entities` and `create_relationships` schema tests

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_685b9e1f768c8327bcbc15bd40739fa9