### PR TITLE
Add schema helper for MM tools

### DIFF
--- a/crates/mm-server/src/lib.rs
+++ b/crates/mm-server/src/lib.rs
@@ -40,7 +40,6 @@ mod resources;
 mod roots;
 
 use clap::Subcommand;
-use mm_utils::IntoJsonSchema;
 use rust_mcp_sdk::schema::{ListResourceTemplatesResult, ListResourcesResult};
 use serde_json::Value;
 
@@ -361,25 +360,13 @@ pub async fn run_tools<P: AsRef<Path>>(command: ToolsCommand, config_paths: &[P]
             if toolbox != "MMTools" {
                 anyhow::bail!("Unknown toolbox: {}", toolbox);
             }
-            let schema = match tool_name.as_str() {
-                "create_entities" => mcp::CreateEntitiesTool::json_schema(),
-                "create_relationships" => mcp::CreateRelationshipsTool::json_schema(),
-                "delete_entities" => mcp::DeleteEntitiesTool::json_schema(),
-                "delete_relationships" => mcp::DeleteRelationshipsTool::json_schema(),
-                "find_entities_by_labels" => mcp::FindEntitiesByLabelsTool::json_schema(),
-                "find_relationships" => mcp::FindRelationshipsTool::json_schema(),
-                "create_tasks" => mcp::CreateTasksTool::json_schema(),
-                "get_task" => mcp::GetTaskTool::json_schema(),
-                "update_task" => mcp::UpdateTaskTool::json_schema(),
-                "delete_task" => mcp::DeleteTaskTool::json_schema(),
-                "get_entity" => mcp::GetEntityTool::json_schema(),
-                "get_git_status" => mcp::GetGitStatusTool::json_schema(),
-                "get_project_context" => mcp::GetProjectContextTool::json_schema(),
-                "list_projects" => mcp::ListProjectsTool::json_schema(),
-                "update_entity" => mcp::UpdateEntityTool::json_schema(),
-                "update_relationship" => mcp::UpdateRelationshipTool::json_schema(),
-                _ => anyhow::bail!("Unknown tool: {}", tool_name),
+            let params = rust_mcp_sdk::schema::CallToolRequestParams {
+                name: tool_name.clone(),
+                arguments: None,
             };
+            let tool = MMTools::try_from(params)
+                .map_err(|_| anyhow::anyhow!("Unknown tool: {}", tool_name))?;
+            let schema = tool.schema();
             println!("{}", serde_json::to_string_pretty(&schema)?);
         }
     }

--- a/crates/mm-server/src/mcp/mod.rs
+++ b/crates/mm-server/src/mcp/mod.rs
@@ -18,7 +18,9 @@ pub mod update_entity;
 pub mod update_relationship;
 pub mod update_task;
 
+use mm_utils::IntoJsonSchema;
 use rust_mcp_sdk::tool_box;
+use serde_json::{Map, Value};
 
 pub use create_entities::CreateEntitiesTool;
 pub use create_relationships::CreateRelationshipsTool;
@@ -92,6 +94,28 @@ impl MMTools {
             MMTools::ListProjectsTool(tool) => tool.call_tool(ports).await,
             MMTools::UpdateEntityTool(tool) => tool.call_tool(ports).await,
             MMTools::UpdateRelationshipTool(tool) => tool.call_tool(ports).await,
+        }
+    }
+
+    /// Return the JSON schema for the contained tool.
+    pub fn schema(&self) -> Map<String, Value> {
+        match self {
+            MMTools::CreateEntitiesTool(_) => CreateEntitiesTool::json_schema(),
+            MMTools::CreateRelationshipsTool(_) => CreateRelationshipsTool::json_schema(),
+            MMTools::DeleteEntitiesTool(_) => DeleteEntitiesTool::json_schema(),
+            MMTools::DeleteRelationshipsTool(_) => DeleteRelationshipsTool::json_schema(),
+            MMTools::FindEntitiesByLabelsTool(_) => FindEntitiesByLabelsTool::json_schema(),
+            MMTools::FindRelationshipsTool(_) => FindRelationshipsTool::json_schema(),
+            MMTools::CreateTasksTool(_) => CreateTasksTool::json_schema(),
+            MMTools::GetTaskTool(_) => GetTaskTool::json_schema(),
+            MMTools::UpdateTaskTool(_) => UpdateTaskTool::json_schema(),
+            MMTools::DeleteTaskTool(_) => DeleteTaskTool::json_schema(),
+            MMTools::GetEntityTool(_) => GetEntityTool::json_schema(),
+            MMTools::GetGitStatusTool(_) => GetGitStatusTool::json_schema(),
+            MMTools::GetProjectContextTool(_) => GetProjectContextTool::json_schema(),
+            MMTools::ListProjectsTool(_) => ListProjectsTool::json_schema(),
+            MMTools::UpdateEntityTool(_) => UpdateEntityTool::json_schema(),
+            MMTools::UpdateRelationshipTool(_) => UpdateRelationshipTool::json_schema(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- expose `MMTools::schema()` to fetch JSON schema for contained tool
- simplify CLI's `ToolsCommand::Schema` to use the enum-based lookup

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_685b9e1c38fc8327873de8fe560fda0c