### PR TITLE
Use strum for task enums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1496,6 +1496,8 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "strum",
+ "strum_macros",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -2657,6 +2659,25 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,5 @@ arbtest = "0.3"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std", "serde"] }
 schemars = { version = "1.0.0-rc.2", features = ["derive"] }
 futures = "0.3"
+strum = "0.27"
+strum_macros = "0.27"

--- a/crates/mm-core/Cargo.toml
+++ b/crates/mm-core/Cargo.toml
@@ -19,6 +19,8 @@ schemars = { workspace = true }
 chrono = { workspace = true }
 futures = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
+strum = { workspace = true }
+strum_macros = { workspace = true }
 
 [dev-dependencies]
 mockall = { workspace = true }

--- a/crates/mm-core/src/operations/memory/tasks/types.rs
+++ b/crates/mm-core/src/operations/memory/tasks/types.rs
@@ -4,9 +4,11 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::str::FromStr;
+use strum_macros::{AsRefStr, EnumString};
 
 /// Priority level for a task
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, EnumString, AsRefStr)]
+#[strum(serialize_all = "lowercase", ascii_case_insensitive)]
 pub enum Priority {
     Low,
     Medium,
@@ -14,70 +16,26 @@ pub enum Priority {
     Critical,
 }
 
-impl FromStr for Priority {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.eq_ignore_ascii_case("low") {
-            Ok(Priority::Low)
-        } else if s.eq_ignore_ascii_case("medium") {
-            Ok(Priority::Medium)
-        } else if s.eq_ignore_ascii_case("high") {
-            Ok(Priority::High)
-        } else if s.eq_ignore_ascii_case("critical") {
-            Ok(Priority::Critical)
-        } else {
-            Err(())
-        }
-    }
-}
-
 /// Status of a task
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, EnumString, AsRefStr)]
+#[strum(serialize_all = "lowercase", ascii_case_insensitive)]
 pub enum TaskStatus {
     Todo,
+    #[strum(serialize = "inprogress", serialize = "in_progress")]
     InProgress,
     Blocked,
     Done,
     Cancelled,
 }
 
-impl FromStr for TaskStatus {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_ascii_lowercase().as_str() {
-            "todo" => Ok(TaskStatus::Todo),
-            "inprogress" | "in_progress" => Ok(TaskStatus::InProgress),
-            "blocked" => Ok(TaskStatus::Blocked),
-            "done" => Ok(TaskStatus::Done),
-            "cancelled" => Ok(TaskStatus::Cancelled),
-            _ => Err(()),
-        }
-    }
-}
-
 /// Type of task
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, EnumString, AsRefStr)]
+#[strum(serialize_all = "lowercase", ascii_case_insensitive)]
 pub enum TaskType {
     Feature,
     Bug,
     Chore,
     Improvement,
-}
-
-impl FromStr for TaskType {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_ascii_lowercase().as_str() {
-            "feature" => Ok(TaskType::Feature),
-            "bug" => Ok(TaskType::Bug),
-            "chore" => Ok(TaskType::Chore),
-            "improvement" => Ok(TaskType::Improvement),
-            _ => Err(()),
-        }
-    }
 }
 
 /// Properties for Task entities
@@ -203,15 +161,15 @@ impl From<TaskProperties> for HashMap<String, MemoryValue> {
         }
         map.insert(
             "task_type".to_string(),
-            MemoryValue::String(format!("{:?}", props.task_type).to_lowercase()),
+            MemoryValue::String(props.task_type.as_ref().to_string()),
         );
         map.insert(
             "status".to_string(),
-            MemoryValue::String(format!("{:?}", props.status).to_lowercase()),
+            MemoryValue::String(props.status.as_ref().to_string()),
         );
         map.insert(
             "priority".to_string(),
-            MemoryValue::String(format!("{:?}", props.priority).to_lowercase()),
+            MemoryValue::String(props.priority.as_ref().to_string()),
         );
         map
     }


### PR DESCRIPTION
## Summary
- add `strum` and `strum_macros` workspace dependencies
- derive `EnumString` and `AsRefStr` for `Priority`, `TaskStatus`, and `TaskType`
- replace manual `FromStr` impls
- adjust property serialization to use `as_ref`

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_685b9e58d1ec8327969d686da5f1e46f