### PR TITLE
Refactor CRUD wrappers with macros

### DIFF
--- a/crates/mm-core/src/operations/memory/common.rs
+++ b/crates/mm-core/src/operations/memory/common.rs
@@ -30,3 +30,104 @@ where
         Err(CoreError::BatchValidation(errors))
     }
 }
+
+/// Generate a simple update wrapper around `update_entity_generic`.
+///
+/// The macro defines a command struct, result type alias and async function
+/// that forwards to `update_entity_generic`.
+#[macro_export]
+macro_rules! generate_update_wrapper {
+    ($command:ident, $func:ident, $result:ident) => {
+        #[derive(Debug, Clone)]
+        pub struct $command {
+            pub name: String,
+            pub update: mm_memory::EntityUpdate,
+        }
+
+        pub type $result<E> = $crate::error::CoreResult<(), E>;
+
+        #[tracing::instrument(skip(ports), fields(name = %command.name))]
+        pub async fn $func<M, G>(
+            ports: &$crate::ports::Ports<M, G>,
+            command: $command,
+        ) -> $result<M::Error>
+        where
+            M: mm_memory::MemoryRepository + Send + Sync,
+            G: mm_git::GitRepository + Send + Sync,
+            M::Error: std::error::Error + Send + Sync + 'static,
+            G::Error: std::error::Error + Send + Sync + 'static,
+        {
+            $crate::operations::memory::generic::update_entity_generic(
+                ports,
+                &command.name,
+                &command.update,
+            )
+            .await
+        }
+    };
+}
+
+/// Generate a simple get wrapper around `get_entity_generic`.
+#[macro_export]
+macro_rules! generate_get_wrapper {
+    ($command:ident, $func:ident, $result:ident, $props:ty) => {
+        #[derive(Debug, Clone)]
+        pub struct $command {
+            pub name: String,
+        }
+
+        pub type $result<E> = $crate::error::CoreResult<Option<mm_memory::MemoryEntity<$props>>, E>;
+
+        #[tracing::instrument(skip(ports), fields(name = %command.name))]
+        pub async fn $func<M, G>(
+            ports: &$crate::ports::Ports<M, G>,
+            command: $command,
+        ) -> $result<M::Error>
+        where
+            M: mm_memory::MemoryRepository + Send + Sync,
+            G: mm_git::GitRepository + Send + Sync,
+            M::Error: std::error::Error + Send + Sync + 'static,
+            G::Error: std::error::Error + Send + Sync + 'static,
+        {
+            $crate::operations::memory::generic::get_entity_generic::<M, G, $props>(
+                ports,
+                &command.name,
+            )
+            .await
+        }
+    };
+}
+
+/// Generate a simple delete wrapper that forwards to `delete_entities`.
+#[macro_export]
+macro_rules! generate_delete_wrapper {
+    ($command:ident, $func:ident, $result:ident) => {
+        #[derive(Debug, Clone)]
+        pub struct $command {
+            pub name: String,
+        }
+
+        pub type $result<E> = $crate::error::CoreResult<(), E>;
+
+        #[tracing::instrument(skip(ports), fields(name = %command.name))]
+        pub async fn $func<M, G>(
+            ports: &$crate::ports::Ports<M, G>,
+            command: $command,
+        ) -> $result<M::Error>
+        where
+            M: mm_memory::MemoryRepository + Send + Sync,
+            G: mm_git::GitRepository + Send + Sync,
+            M::Error: std::error::Error + Send + Sync + 'static,
+            G::Error: std::error::Error + Send + Sync + 'static,
+        {
+            validate_name!(command.name);
+            $crate::operations::memory::delete_entities(
+                ports,
+                $crate::operations::memory::DeleteEntitiesCommand {
+                    names: vec![command.name],
+                },
+            )
+            .await
+        }
+    };
+}

--- a/crates/mm-core/src/operations/memory/get_entity.rs
+++ b/crates/mm-core/src/operations/memory/get_entity.rs
@@ -1,54 +1,19 @@
 #[cfg(test)]
 use crate::error::CoreError;
-use crate::error::CoreResult;
-use crate::operations::memory::generic::get_entity_generic;
-use crate::ports::Ports;
-use mm_git::GitRepository;
+#[cfg(test)]
 use mm_memory::MemoryEntity;
-use mm_memory::MemoryRepository;
-use tracing::instrument;
 
-/// Command to retrieve an entity by name
-#[derive(Debug, Clone)]
-pub struct GetEntityCommand {
-    pub name: String,
-}
-
-/// Error types that can occur when getting an entity
-/// Result type for the get_entity operation
-pub type GetEntityResult<E> = CoreResult<Option<MemoryEntity>, E>;
-
-/// Get an entity by name
-///
-/// # Arguments
-///
-/// * `ports` - The ports containing required services
-/// * `command` - The command containing the entity name to retrieve
-///
-/// # Returns
-///
-/// The entity if found, or None if not found
-#[instrument(skip(ports), fields(name = %command.name))]
-pub async fn get_entity<M, G>(
-    ports: &Ports<M, G>,
-    command: GetEntityCommand,
-) -> GetEntityResult<M::Error>
-where
-    M: MemoryRepository + Send + Sync,
-    G: GitRepository + Send + Sync,
-    M::Error: std::error::Error + Send + Sync + 'static,
-    G::Error: std::error::Error + Send + Sync + 'static,
-{
-    get_entity_generic::<M, G, std::collections::HashMap<String, mm_memory::value::MemoryValue>>(
-        ports,
-        &command.name,
-    )
-    .await
-}
+generate_get_wrapper!(
+    GetEntityCommand,
+    get_entity,
+    GetEntityResult,
+    std::collections::HashMap<String, mm_memory::value::MemoryValue>
+);
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ports::Ports;
     use mm_git::repository::MockGitRepository;
     use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository, ValidationErrorKind};
     use mockall::predicate::*;

--- a/crates/mm-core/src/operations/memory/tasks/delete_task.rs
+++ b/crates/mm-core/src/operations/memory/tasks/delete_task.rs
@@ -1,45 +1,12 @@
 #[cfg(test)]
 use crate::error::CoreError;
-use crate::error::CoreResult;
-use crate::operations::memory::{DeleteEntitiesCommand, delete_entities};
-use crate::ports::Ports;
-use crate::validate_name;
-use mm_git::GitRepository;
-use mm_memory::MemoryRepository;
-use tracing::instrument;
 
-#[derive(Debug, Clone)]
-pub struct DeleteTaskCommand {
-    pub name: String,
-}
-
-pub type DeleteTaskResult<E> = CoreResult<(), E>;
-
-#[instrument(skip(ports), fields(name = %command.name))]
-pub async fn delete_task<M, G>(
-    ports: &Ports<M, G>,
-    command: DeleteTaskCommand,
-) -> DeleteTaskResult<M::Error>
-where
-    M: MemoryRepository + Send + Sync,
-    G: GitRepository + Send + Sync,
-    M::Error: std::error::Error + Send + Sync + 'static,
-    G::Error: std::error::Error + Send + Sync + 'static,
-{
-    validate_name!(command.name);
-
-    delete_entities(
-        ports,
-        DeleteEntitiesCommand {
-            names: vec![command.name],
-        },
-    )
-    .await
-}
+generate_delete_wrapper!(DeleteTaskCommand, delete_task, DeleteTaskResult);
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ports::Ports;
     use mm_git::repository::MockGitRepository;
     use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
     use std::sync::Arc;

--- a/crates/mm-core/src/operations/memory/tasks/get_task.rs
+++ b/crates/mm-core/src/operations/memory/tasks/get_task.rs
@@ -1,34 +1,15 @@
 use super::types::TaskProperties;
 #[cfg(test)]
 use crate::error::CoreError;
-use crate::error::CoreResult;
-use crate::operations::memory::generic::get_entity_generic;
-use crate::ports::Ports;
-use mm_git::GitRepository;
-use mm_memory::{MemoryEntity, MemoryRepository};
-use tracing::instrument;
+#[cfg(test)]
+use mm_memory::MemoryEntity;
 
-#[derive(Debug, Clone)]
-pub struct GetTaskCommand {
-    pub name: String,
-}
-
-pub type GetTaskResult<E> = CoreResult<Option<MemoryEntity<TaskProperties>>, E>;
-
-#[instrument(skip(ports), fields(name = %command.name))]
-pub async fn get_task<M, G>(ports: &Ports<M, G>, command: GetTaskCommand) -> GetTaskResult<M::Error>
-where
-    M: MemoryRepository + Send + Sync,
-    G: GitRepository + Send + Sync,
-    M::Error: std::error::Error + Send + Sync + 'static,
-    G::Error: std::error::Error + Send + Sync + 'static,
-{
-    get_entity_generic::<M, G, TaskProperties>(ports, &command.name).await
-}
+generate_get_wrapper!(GetTaskCommand, get_task, GetTaskResult, TaskProperties);
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ports::Ports;
     use mm_git::repository::MockGitRepository;
     use mm_memory::labels::TASK_LABEL;
     use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};

--- a/crates/mm-core/src/operations/memory/tasks/update_task.rs
+++ b/crates/mm-core/src/operations/memory/tasks/update_task.rs
@@ -1,37 +1,14 @@
 #[cfg(test)]
 use crate::error::CoreError;
-use crate::error::CoreResult;
-use crate::operations::memory::generic::update_entity_generic;
-use crate::ports::Ports;
-use mm_git::GitRepository;
-use mm_memory::{EntityUpdate, MemoryRepository};
-use tracing::instrument;
+#[cfg(test)]
+use mm_memory::EntityUpdate;
 
-#[derive(Debug, Clone)]
-pub struct UpdateTaskCommand {
-    pub name: String,
-    pub update: EntityUpdate,
-}
-
-pub type UpdateTaskResult<E> = CoreResult<(), E>;
-
-#[instrument(skip(ports), fields(name = %command.name))]
-pub async fn update_task<M, G>(
-    ports: &Ports<M, G>,
-    command: UpdateTaskCommand,
-) -> UpdateTaskResult<M::Error>
-where
-    M: MemoryRepository + Send + Sync,
-    G: GitRepository + Send + Sync,
-    M::Error: std::error::Error + Send + Sync + 'static,
-    G::Error: std::error::Error + Send + Sync + 'static,
-{
-    update_entity_generic(ports, &command.name, &command.update).await
-}
+generate_update_wrapper!(UpdateTaskCommand, update_task, UpdateTaskResult);
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ports::Ports;
     use mm_git::repository::MockGitRepository;
     use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
     use std::sync::Arc;

--- a/crates/mm-core/src/operations/memory/update_entity.rs
+++ b/crates/mm-core/src/operations/memory/update_entity.rs
@@ -1,37 +1,14 @@
 #[cfg(test)]
 use crate::error::CoreError;
-use crate::error::CoreResult;
-use crate::operations::memory::generic::update_entity_generic;
-use crate::ports::Ports;
-use mm_git::GitRepository;
-use mm_memory::{EntityUpdate, MemoryRepository};
-use tracing::instrument;
+#[cfg(test)]
+use mm_memory::EntityUpdate;
 
-#[derive(Debug, Clone)]
-pub struct UpdateEntityCommand {
-    pub name: String,
-    pub update: EntityUpdate,
-}
-
-pub type UpdateEntityResult<E> = CoreResult<(), E>;
-
-#[instrument(skip(ports), fields(name = %command.name))]
-pub async fn update_entity<M, G>(
-    ports: &Ports<M, G>,
-    command: UpdateEntityCommand,
-) -> UpdateEntityResult<M::Error>
-where
-    M: MemoryRepository + Send + Sync,
-    G: GitRepository + Send + Sync,
-    M::Error: std::error::Error + Send + Sync + 'static,
-    G::Error: std::error::Error + Send + Sync + 'static,
-{
-    update_entity_generic(ports, &command.name, &command.update).await
-}
+generate_update_wrapper!(UpdateEntityCommand, update_entity, UpdateEntityResult);
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ports::Ports;
     use mm_git::repository::MockGitRepository;
     use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
     use std::sync::Arc;


### PR DESCRIPTION
## Summary
- add macro helpers in `common.rs` for update/get/delete wrappers
- replace manual implementations in CRUD modules with macro invocations
- adjust tests to import Ports and gate test-only imports

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_685b9f2812688327963d14dd3efcdeaf