### PR TITLE
Use discover for repo detection

### DIFF
--- a/crates/mm-git-git2/src/repository.rs
+++ b/crates/mm-git-git2/src/repository.rs
@@ -25,7 +25,7 @@ impl GitRepository for Git2Repository {
     async fn get_status(&self, path: &Path) -> GitResult<GitStatus, Self::Error> {
         let path: PathBuf = path.to_path_buf();
         let res = task::spawn_blocking(move || -> Result<GitStatus, git2::Error> {
-            let repo = Repository::open(path)?;
+            let repo = Repository::discover(path)?;
             let head = repo.head()?;
             let branch = head
                 .shorthand()

--- a/crates/mm-git-git2/tests/git2_repository.rs
+++ b/crates/mm-git-git2/tests/git2_repository.rs
@@ -30,6 +30,18 @@ async fn test_get_status_success() {
 }
 
 #[tokio::test]
+async fn test_get_status_nested_directory() {
+    let dir = TempDir::new().unwrap();
+    let repo = init_repo(&dir);
+    let expected_branch = repo.head().unwrap().shorthand().unwrap().to_string();
+    let nested = dir.path().join("nested/dir");
+    std::fs::create_dir_all(&nested).unwrap();
+    let service = create_git_service();
+    let status = service.get_status(&nested).await.unwrap();
+    assert_eq!(status.branch, expected_branch);
+}
+
+#[tokio::test]
 async fn test_get_status_invalid_path() {
     let repo = Git2Repository::new();
     let path = std::path::Path::new("/nonexistent/path");


### PR DESCRIPTION
## Summary
- use `Repository::discover` to locate repos from nested paths
- add a nested directory test

## Testing
- `just validate`
- `cargo test -p mm-git-git2`

------
https://chatgpt.com/codex/tasks/task_e_685c278a663083279b0e4ff0e965572a