### PR TITLE
Improve git status

### DIFF
--- a/crates/mm-core/src/operations/git/status.rs
+++ b/crates/mm-core/src/operations/git/status.rs
@@ -42,6 +42,10 @@ mod tests {
         git_repo.expect_get_status().returning(|_| {
             Ok(GitStatus {
                 branch: "main".to_string(),
+                is_dirty: false,
+                ahead_by: 0,
+                behind_by: 0,
+                changed_files: vec![],
             })
         });
 
@@ -58,7 +62,12 @@ mod tests {
 
         // Assert the result
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().branch, "main");
+        let status = result.unwrap();
+        assert_eq!(status.branch, "main");
+        assert!(!status.is_dirty);
+        assert_eq!(status.ahead_by, 0);
+        assert_eq!(status.behind_by, 0);
+        assert!(status.changed_files.is_empty());
     }
 
     #[tokio::test]

--- a/crates/mm-git-git2/tests/git2_repository.rs
+++ b/crates/mm-git-git2/tests/git2_repository.rs
@@ -27,6 +27,10 @@ async fn test_get_status_success() {
     let service = create_git_service();
     let status = service.get_status(dir.path()).await.unwrap();
     assert_eq!(status.branch, expected_branch);
+    assert!(!status.is_dirty);
+    assert_eq!(status.ahead_by, 0);
+    assert_eq!(status.behind_by, 0);
+    assert!(status.changed_files.is_empty());
 }
 
 #[tokio::test]

--- a/crates/mm-git/src/repository.rs
+++ b/crates/mm-git/src/repository.rs
@@ -10,6 +10,10 @@ use crate::status::GitStatus;
 pub trait GitRepository {
     type Error: StdError + Send + Sync + 'static;
 
-    /// Get the status of a Git repository
+    /// Get the status of a Git repository.
+    ///
+    /// The returned [`GitStatus`] includes the current branch name, whether the
+    /// working tree has uncommitted changes, how many commits the branch is
+    /// ahead or behind its upstream, and the list of changed files.
     async fn get_status(&self, path: &Path) -> GitResult<GitStatus, Self::Error>;
 }

--- a/crates/mm-git/src/service.rs
+++ b/crates/mm-git/src/service.rs
@@ -39,12 +39,20 @@ mod tests {
         let mut mock = MockGitRepository::new();
         let expected = GitStatus {
             branch: "main".to_string(),
+            is_dirty: false,
+            ahead_by: 0,
+            behind_by: 0,
+            changed_files: vec![],
         };
         mock.expect_get_status()
             .withf(|p| p == Path::new("/tmp/repo"))
             .returning(|_| {
                 Ok(GitStatus {
                     branch: "main".to_string(),
+                    is_dirty: false,
+                    ahead_by: 0,
+                    behind_by: 0,
+                    changed_files: vec![],
                 })
             });
 
@@ -52,5 +60,9 @@ mod tests {
         let path = PathBuf::from("/tmp/repo");
         let status = service.get_status(&path).await.unwrap();
         assert_eq!(status.branch, expected.branch);
+        assert_eq!(status.is_dirty, expected.is_dirty);
+        assert_eq!(status.ahead_by, expected.ahead_by);
+        assert_eq!(status.behind_by, expected.behind_by);
+        assert_eq!(status.changed_files, expected.changed_files);
     }
 }

--- a/crates/mm-git/src/status.rs
+++ b/crates/mm-git/src/status.rs
@@ -6,4 +6,12 @@ use serde::{Deserialize, Serialize};
 pub struct GitStatus {
     /// Current branch name
     pub branch: String,
+    /// Whether the working tree has uncommitted changes
+    pub is_dirty: bool,
+    /// Number of commits the local branch is ahead of its upstream
+    pub ahead_by: u32,
+    /// Number of commits the local branch is behind its upstream
+    pub behind_by: u32,
+    /// Paths of files that have been modified
+    pub changed_files: Vec<String>,
 }

--- a/crates/mm-server/src/mcp/get_git_status.rs
+++ b/crates/mm-server/src/mcp/get_git_status.rs
@@ -19,6 +19,14 @@ pub struct GetGitStatusTool {
 pub struct GetGitStatusResponse {
     /// Current branch name
     pub branch: String,
+    /// Whether the working tree has uncommitted changes
+    pub is_dirty: bool,
+    /// Commits ahead of the upstream branch
+    pub ahead_by: u32,
+    /// Commits behind the upstream branch
+    pub behind_by: u32,
+    /// Paths of files that have been modified
+    pub changed_files: Vec<String>,
 }
 
 impl GetGitStatusTool {
@@ -40,6 +48,10 @@ mod tests {
         git_repo.expect_get_status().returning(|_| {
             Ok(GitStatus {
                 branch: "main".to_string(),
+                is_dirty: false,
+                ahead_by: 0,
+                behind_by: 0,
+                changed_files: vec![],
             })
         });
 
@@ -65,6 +77,16 @@ mod tests {
         let json: serde_json::Value = serde_json::from_str(&text).unwrap();
         let branch = json.get("branch").unwrap().as_str().unwrap();
         assert_eq!(branch, "main");
+        assert_eq!(json.get("is_dirty").unwrap().as_bool().unwrap(), false);
+        assert_eq!(json.get("ahead_by").unwrap().as_u64().unwrap(), 0);
+        assert_eq!(json.get("behind_by").unwrap().as_u64().unwrap(), 0);
+        assert!(
+            json.get("changed_files")
+                .unwrap()
+                .as_array()
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[tokio::test]

--- a/crates/mm-server/src/mcp/get_git_status.rs
+++ b/crates/mm-server/src/mcp/get_git_status.rs
@@ -77,7 +77,7 @@ mod tests {
         let json: serde_json::Value = serde_json::from_str(&text).unwrap();
         let branch = json.get("branch").unwrap().as_str().unwrap();
         assert_eq!(branch, "main");
-        assert_eq!(json.get("is_dirty").unwrap().as_bool().unwrap(), false);
+        assert!(!json.get("is_dirty").unwrap().as_bool().unwrap());
         assert_eq!(json.get("ahead_by").unwrap().as_u64().unwrap(), 0);
         assert_eq!(json.get("behind_by").unwrap().as_u64().unwrap(), 0);
         assert!(


### PR DESCRIPTION
## Summary
- extend git status with dirtiness, ahead/behind counts, and changed files
- populate the new fields using git2 APIs
- document new return values and adapt mock-based tests
- expose enriched fields in the MCP tool and CLI tests

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_685c28047e088327ad2e80c0f274061a