### PR TITLE
Add typed repository API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1552,6 +1552,7 @@ dependencies = [
  "mm-memory",
  "mockall",
  "neo4rs",
+ "schemars",
  "serde",
  "serde_json",
  "thiserror 1.0.69",

--- a/crates/mm-core/src/operations/memory/find_entities_by_labels.rs
+++ b/crates/mm-core/src/operations/memory/find_entities_by_labels.rs
@@ -1,7 +1,7 @@
 use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
 use mm_git::GitRepository;
-use mm_memory::{LabelMatchMode, MemoryEntity, MemoryRepository};
+use mm_memory::{BasicEntityProperties, LabelMatchMode, MemoryEntity, MemoryRepository};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
@@ -33,7 +33,7 @@ where
 {
     let entities = ports
         .memory_service
-        .find_entities_by_labels(
+        .find_entities_by_labels_typed::<BasicEntityProperties>(
             &command.labels,
             command.match_mode,
             command.required_label.clone(),

--- a/crates/mm-core/src/operations/memory/generic.rs
+++ b/crates/mm-core/src/operations/memory/generic.rs
@@ -2,9 +2,8 @@ use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
 use crate::validate_name;
 use mm_git::GitRepository;
-use mm_memory::{EntityUpdate, MemoryEntity, MemoryRepository, value::MemoryValue};
+use mm_memory::{BasicEntityProperties, EntityUpdate, MemoryEntity, MemoryRepository};
 use schemars::JsonSchema;
-use std::collections::HashMap;
 use tracing::instrument;
 
 pub type UpdateEntityGenericResult<E> = CoreResult<(), E>;
@@ -43,11 +42,12 @@ where
     M::Error: std::error::Error + Send + Sync + 'static,
     G::Error: std::error::Error + Send + Sync + 'static,
     P: JsonSchema
-        + From<HashMap<String, MemoryValue>>
-        + Into<HashMap<String, MemoryValue>>
+        + From<BasicEntityProperties>
+        + Into<BasicEntityProperties>
         + Clone
         + std::fmt::Debug
-        + Default,
+        + Default
+        + 'static,
 {
     validate_name!(name);
 

--- a/crates/mm-core/src/operations/memory/get_entity.rs
+++ b/crates/mm-core/src/operations/memory/get_entity.rs
@@ -7,7 +7,7 @@ generate_get_wrapper!(
     GetEntityCommand,
     get_entity,
     GetEntityResult,
-    std::collections::HashMap<String, mm_memory::value::MemoryValue>
+    mm_memory::BasicEntityProperties
 );
 
 #[cfg(test)]
@@ -29,7 +29,7 @@ mod tests {
         };
 
         mock_repo
-            .expect_find_entity_by_name()
+            .expect_find_entity_by_name_typed::<mm_memory::BasicEntityProperties>()
             .with(eq("test:entity"))
             .returning(move |_| Ok(Some(entity.clone())));
 
@@ -49,7 +49,9 @@ mod tests {
     #[tokio::test]
     async fn test_get_entity_empty_name() {
         let mut mock_repo = MockMemoryRepository::new();
-        mock_repo.expect_find_entity_by_name().never();
+        mock_repo
+            .expect_find_entity_by_name_typed::<mm_memory::BasicEntityProperties>()
+            .never();
         let service = MemoryService::new(mock_repo, MemoryConfig::default());
         let git_repo = MockGitRepository::new();
         let git_service = mm_git::GitService::new(git_repo);
@@ -72,7 +74,7 @@ mod tests {
 
         let mut mock_repo = MockMemoryRepository::new();
         mock_repo
-            .expect_find_entity_by_name()
+            .expect_find_entity_by_name_typed::<mm_memory::BasicEntityProperties>()
             .with(eq("test:entity"))
             .returning(|_| Err(MemoryError::query_error("db error")));
 
@@ -94,7 +96,7 @@ mod tests {
     async fn test_get_entity_not_found() {
         let mut mock_repo = MockMemoryRepository::new();
         mock_repo
-            .expect_find_entity_by_name()
+            .expect_find_entity_by_name_typed::<mm_memory::BasicEntityProperties>()
             .with(eq("missing:entity"))
             .returning(|_| Ok(None));
 
@@ -121,7 +123,7 @@ mod tests {
             let mut mock_repo = MockMemoryRepository::new();
             let name_clone = name.clone();
             mock_repo
-                .expect_find_entity_by_name()
+                .expect_find_entity_by_name_typed::<mm_memory::BasicEntityProperties>()
                 .withf(move |n| n == name_clone)
                 .returning(|_| Ok(None));
             let service = MemoryService::new(mock_repo, MemoryConfig::default());
@@ -139,7 +141,9 @@ mod tests {
     fn prop_get_entity_empty_name() {
         async_arbtest(|rt, _| {
             let mut mock_repo = MockMemoryRepository::new();
-            mock_repo.expect_find_entity_by_name().never();
+            mock_repo
+                .expect_find_entity_by_name_typed::<mm_memory::BasicEntityProperties>()
+                .never();
             let service = MemoryService::new(mock_repo, MemoryConfig::default());
             let git_repo = MockGitRepository::new();
             let git_service = mm_git::GitService::new(git_repo);

--- a/crates/mm-core/src/operations/memory/get_project_context.rs
+++ b/crates/mm-core/src/operations/memory/get_project_context.rs
@@ -1,6 +1,7 @@
 use mm_git::GitRepository;
 use mm_memory::{
-    MemoryEntity, MemoryError, MemoryRepository, ProjectContext, RelationshipDirection,
+    BasicEntityProperties, MemoryEntity, MemoryError, MemoryRepository, ProjectContext,
+    RelationshipDirection,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -53,7 +54,12 @@ where
     let label_string = label.to_string();
     let entities = ports
         .memory_service
-        .find_related_entities(entity_name, relationship, direction, depth)
+        .find_related_entities_typed::<BasicEntityProperties>(
+            entity_name,
+            relationship,
+            direction,
+            depth,
+        )
         .await
         .map_err(CoreError::from)?
         .into_iter()
@@ -79,7 +85,7 @@ where
             // Try to find the project by name
             let project_entity = ports
                 .memory_service
-                .find_entity_by_name(&name)
+                .find_entity_by_name_typed::<BasicEntityProperties>(&name)
                 .await
                 .map_err(CoreError::from)?;
 
@@ -95,7 +101,7 @@ where
             let repo_name = format!("tech:git:repo:{}", repo_name);
             let repo_entity = ports
                 .memory_service
-                .find_entity_by_name(&repo_name)
+                .find_entity_by_name_typed::<BasicEntityProperties>(&repo_name)
                 .await
                 .map_err(CoreError::from)?;
 
@@ -181,7 +187,12 @@ where
     // Find other entities related to this project
     let other_related = ports
         .memory_service
-        .find_related_entities(&project.name, None, Some(RelationshipDirection::Both), 1)
+        .find_related_entities_typed::<BasicEntityProperties>(
+            &project.name,
+            None,
+            Some(RelationshipDirection::Both),
+            1,
+        )
         .await
         .map_err(CoreError::from)?
         .into_iter()

--- a/crates/mm-core/src/operations/memory/list_projects.rs
+++ b/crates/mm-core/src/operations/memory/list_projects.rs
@@ -1,6 +1,6 @@
 use mm_git::GitRepository;
 use mm_memory::labels::PROJECT_LABEL;
-use mm_memory::{LabelMatchMode, MemoryEntity, MemoryRepository};
+use mm_memory::{BasicEntityProperties, LabelMatchMode, MemoryEntity, MemoryRepository};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
@@ -37,7 +37,11 @@ where
     // Find all projects
     let mut projects = ports
         .memory_service
-        .find_entities_by_labels(&[PROJECT_LABEL.to_string()], LabelMatchMode::All, None)
+        .find_entities_by_labels_typed::<BasicEntityProperties>(
+            &[PROJECT_LABEL.to_string()],
+            LabelMatchMode::All,
+            None,
+        )
         .await
         .map_err(CoreError::from)?;
 
@@ -83,7 +87,7 @@ mod tests {
         };
 
         mock_repo
-            .expect_find_entities_by_labels()
+            .expect_find_entities_by_labels_typed::<BasicEntityProperties>()
             .with(
                 eq(vec![PROJECT_LABEL.to_string()]),
                 eq(LabelMatchMode::All),
@@ -128,7 +132,7 @@ mod tests {
         };
 
         mock_repo
-            .expect_find_entities_by_labels()
+            .expect_find_entities_by_labels_typed::<BasicEntityProperties>()
             .with(
                 eq(vec![PROJECT_LABEL.to_string()]),
                 eq(LabelMatchMode::All),
@@ -158,7 +162,7 @@ mod tests {
 
         // Setup mock for find_entities_by_labels
         mock_repo
-            .expect_find_entities_by_labels()
+            .expect_find_entities_by_labels_typed::<BasicEntityProperties>()
             .with(
                 eq(vec![PROJECT_LABEL.to_string()]),
                 eq(LabelMatchMode::All),

--- a/crates/mm-core/src/operations/memory/tasks/get_task.rs
+++ b/crates/mm-core/src/operations/memory/tasks/get_task.rs
@@ -24,7 +24,7 @@ mod tests {
             labels: vec![TASK_LABEL.to_string()],
             ..Default::default()
         };
-        mock.expect_find_entity_by_name()
+        mock.expect_find_entity_by_name_typed::<TaskProperties>()
             .with(eq("task:1"))
             .returning(move |_| Ok(Some(entity.clone())));
 
@@ -43,7 +43,8 @@ mod tests {
     #[tokio::test]
     async fn test_get_task_empty_name() {
         let mut mock = MockMemoryRepository::new();
-        mock.expect_find_entity_by_name().never();
+        mock.expect_find_entity_by_name_typed::<TaskProperties>()
+            .never();
         let service = MemoryService::new(mock, MemoryConfig::default());
         let git_repo = MockGitRepository::new();
         let git_service = mm_git::GitService::new(git_repo);

--- a/crates/mm-memory-neo4j/Cargo.toml
+++ b/crates/mm-memory-neo4j/Cargo.toml
@@ -13,6 +13,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 async-trait = { workspace = true }
 mm-memory = { path = "../mm-memory" }
+schemars = { workspace = true }
 chrono = { workspace = true }
 
 [dev-dependencies]

--- a/crates/mm-memory/src/entity.rs
+++ b/crates/mm-memory/src/entity.rs
@@ -1,17 +1,16 @@
+use crate::BasicEntityProperties;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 use crate::relationship::MemoryRelationship;
-use crate::value::MemoryValue;
 
 /// Memory entity representing a node in the knowledge graph
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, JsonSchema, Default)]
-pub struct MemoryEntity<P = HashMap<String, MemoryValue>>
+pub struct MemoryEntity<P = BasicEntityProperties>
 where
     P: JsonSchema
-        + Into<HashMap<String, MemoryValue>>
-        + From<HashMap<String, MemoryValue>>
+        + Into<BasicEntityProperties>
+        + From<BasicEntityProperties>
         + Clone
         + std::fmt::Debug
         + Default,

--- a/crates/mm-memory/src/lib.rs
+++ b/crates/mm-memory/src/lib.rs
@@ -32,6 +32,9 @@ pub use update::{
 pub use validation_error::{ValidationError, ValidationErrorKind};
 pub use value::MemoryValue;
 
+/// Basic property map type used by default with [`MemoryEntity`]
+pub type BasicEntityProperties = std::collections::HashMap<String, MemoryValue>;
+
 #[cfg(test)]
 pub mod test_helpers;
 

--- a/crates/mm-server/src/mcp/get_entity.rs
+++ b/crates/mm-server/src/mcp/get_entity.rs
@@ -22,6 +22,7 @@ impl GetEntityTool {
 mod tests {
     use super::*;
     use mm_core::Ports;
+    use mm_memory::BasicEntityProperties;
     use mm_memory::{MemoryConfig, MemoryEntity, MemoryError, MemoryService, MockMemoryRepository};
     use mockall::predicate::*;
     use serde_json::Value;
@@ -36,7 +37,7 @@ mod tests {
         };
 
         let mut mock = MockMemoryRepository::new();
-        mock.expect_find_entity_by_name()
+        mock.expect_find_entity_by_name_typed::<BasicEntityProperties>()
             .with(eq("test:entity"))
             .returning(move |_| Ok(Some(entity.clone())));
 
@@ -57,7 +58,7 @@ mod tests {
     #[tokio::test]
     async fn test_call_tool_repository_error() {
         let mut mock = MockMemoryRepository::new();
-        mock.expect_find_entity_by_name()
+        mock.expect_find_entity_by_name_typed::<BasicEntityProperties>()
             .returning(|_| Err(MemoryError::query_error("fail")));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
@@ -74,7 +75,7 @@ mod tests {
     #[tokio::test]
     async fn test_call_tool_not_found() {
         let mut mock = MockMemoryRepository::new();
-        mock.expect_find_entity_by_name()
+        mock.expect_find_entity_by_name_typed::<BasicEntityProperties>()
             .with(eq("missing"))
             .returning(|_| Ok(None));
 

--- a/crates/mm-server/src/mcp/get_project_context.rs
+++ b/crates/mm-server/src/mcp/get_project_context.rs
@@ -43,6 +43,7 @@ mod tests {
     use super::*;
     use mm_core::Ports;
     use mm_core::operations::memory::{PROJECT_LABEL, TECHNOLOGY_LABEL};
+    use mm_memory::BasicEntityProperties;
     use mm_memory::{MemoryConfig, MemoryEntity, MemoryService, MockMemoryRepository};
     use mockall::predicate::*;
     use std::collections::HashMap;
@@ -76,13 +77,13 @@ mod tests {
 
         // Clone entities for each closure to avoid moved value errors
         let project_entity_clone1 = project_entity.clone();
-        mock.expect_find_entity_by_name()
+        mock.expect_find_entity_by_name_typed::<BasicEntityProperties>()
             .with(eq("andoriyu:project:middle_manager"))
             .returning(move |_| Ok(Some(project_entity_clone1.clone())));
 
         let project_entity_clone2 = project_entity.clone();
         let related_entity_clone = related_entity.clone();
-        mock.expect_find_related_entities()
+        mock.expect_find_related_entities_typed::<BasicEntityProperties>()
             .with(
                 eq("andoriyu:project:middle_manager"),
                 always(),

--- a/crates/mm-server/src/mcp/get_task.rs
+++ b/crates/mm-server/src/mcp/get_task.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use mm_core::operations::memory::TaskProperties;
 use mm_core::operations::memory::{GetTaskCommand, get_task};
 use mm_utils::IntoJsonSchema;
 use rust_mcp_sdk::macros::mcp_tool;
@@ -38,7 +40,7 @@ mod tests {
             ..Default::default()
         };
         let mut mock = MockMemoryRepository::new();
-        mock.expect_find_entity_by_name()
+        mock.expect_find_entity_by_name_typed::<TaskProperties>()
             .with(eq("task:1"))
             .returning(move |_| Ok(Some(entity.clone())));
 

--- a/crates/mm-server/src/mcp/list_projects.rs
+++ b/crates/mm-server/src/mcp/list_projects.rs
@@ -26,6 +26,7 @@ mod tests {
     use super::*;
     use mm_core::Ports;
     use mm_core::operations::memory::PROJECT_LABEL;
+    use mm_memory::BasicEntityProperties;
     use mm_memory::{MemoryConfig, MemoryEntity, MemoryService, MockMemoryRepository};
     use mockall::predicate::*;
     use std::collections::HashMap;
@@ -50,7 +51,7 @@ mod tests {
         };
 
         let mut mock = MockMemoryRepository::new();
-        mock.expect_find_entities_by_labels()
+        mock.expect_find_entities_by_labels_typed::<BasicEntityProperties>()
             .with(
                 eq(vec![PROJECT_LABEL.to_string()]),
                 eq(mm_memory::LabelMatchMode::All),
@@ -89,7 +90,7 @@ mod tests {
         };
 
         let mut mock = MockMemoryRepository::new();
-        mock.expect_find_entities_by_labels()
+        mock.expect_find_entities_by_labels_typed::<BasicEntityProperties>()
             .with(
                 eq(vec![PROJECT_LABEL.to_string()]),
                 eq(mm_memory::LabelMatchMode::All),

--- a/crates/mm-server/src/resources.rs
+++ b/crates/mm-server/src/resources.rs
@@ -81,6 +81,7 @@ where
 mod tests {
     use super::*;
     use mm_git::repository::MockGitRepository;
+    use mm_memory::BasicEntityProperties;
     use mm_memory::{MemoryConfig, MemoryEntity, MemoryService, MockMemoryRepository};
     use mockall::predicate::*;
     use std::sync::Arc;
@@ -94,7 +95,7 @@ mod tests {
         };
 
         let mut mock = MockMemoryRepository::new();
-        mock.expect_find_entity_by_name()
+        mock.expect_find_entity_by_name_typed::<BasicEntityProperties>()
             .with(eq("test:entity"))
             .returning(move |_| Ok(Some(entity.clone())));
 
@@ -115,7 +116,7 @@ mod tests {
     #[tokio::test]
     async fn test_read_resource_not_found() {
         let mut mock = MockMemoryRepository::new();
-        mock.expect_find_entity_by_name()
+        mock.expect_find_entity_by_name_typed::<BasicEntityProperties>()
             .with(eq("missing"))
             .returning(|_| Ok(None));
         let service = MemoryService::new(mock, MemoryConfig::default());
@@ -143,6 +144,7 @@ mod prop_tests {
     use super::*;
     use arbitrary::{Arbitrary, Unstructured};
     use mm_git::repository::MockGitRepository;
+    use mm_memory::BasicEntityProperties;
     use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
     use mm_utils::prop::{NonEmptyName, async_arbtest};
     use std::sync::Arc;
@@ -154,7 +156,7 @@ mod prop_tests {
             let uri = format!("memory://{}", name);
             let mut mock = MockMemoryRepository::new();
             let name_clone = name.clone();
-            mock.expect_find_entity_by_name()
+            mock.expect_find_entity_by_name_typed::<BasicEntityProperties>()
                 .withf(move |n| n == name_clone)
                 .returning(|_| Ok(None));
             let service = MemoryService::new(mock, MemoryConfig::default());
@@ -185,7 +187,8 @@ mod prop_tests {
         async_arbtest(|rt, u| {
             let InvalidUri(uri) = InvalidUri::arbitrary(u)?;
             let mut mock = MockMemoryRepository::new();
-            mock.expect_find_entity_by_name().never();
+            mock.expect_find_entity_by_name_typed::<BasicEntityProperties>()
+                .never();
             let service = MemoryService::new(mock, MemoryConfig::default());
             let git_repo = MockGitRepository::new();
             let git_service = mm_git::GitService::new(git_repo);


### PR DESCRIPTION
## Summary
- add BasicEntityProperties alias for default property map
- use alias in typed repository methods and service helpers
- update tests and typed calls across crates
- move BasicEntityProperties imports into test modules

## Testing
- `just validate`


------
https://chatgpt.com/codex/tasks/task_e_685c281cd54883279f2e63189d65bf69