### PR TITLE
Upgrade schemars to 1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,9 +2459,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "febc07c7e70b5db4f023485653c754d76e1bbe8d9dbfa20193ce13da9f9633f4"
+checksum = "fe8c9d1c68d67dd9f97ecbc6f932b60eb289c5dbddd8aa1405484a8fd2fcd984"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -2472,9 +2472,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1eeedaab7b1e1d09b5b4661121f4d27f9e7487089b0117833ccd7a882ee1ecc"
+checksum = "6ca9fcb757952f8e8629b9ab066fc62da523c46c2b247b1708a3be06dd82530b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rand = "0.8"
 fastrand = "2"
 arbtest = "0.3"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std", "serde"] }
-schemars = { version = "1.0.0-rc.2", features = ["derive"] }
+schemars = { version = "1.0.1", features = ["derive"] }
 futures = "0.3"
 strum = "0.27"
 strum_macros = "0.27"


### PR DESCRIPTION
## Summary
- update schemars dependency to 1.0.1
- update lockfile

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_685c453209488327ba05732e5794a0ae