### PR TITLE
Replace ToolError with anyhow::Error in mm-server

### DIFF
--- a/crates/mm-server/src/mcp/get_project_context.rs
+++ b/crates/mm-server/src/mcp/get_project_context.rs
@@ -25,12 +25,11 @@ impl GetProjectContextTool {
                 (Some(name), _) => ProjectFilter::Name(name),
                 (None, Some(repo)) => ProjectFilter::Repository(repo),
                 (None, None) => {
-                    return Err(rust_mcp_sdk::schema::schema_utils::CallToolError(
+                    return Err(crate::mcp::error::into_call_tool_error(
                         crate::mcp::error::error_with_source(
                             "Either project_name or repository_name must be provided",
                             std::io::Error::new(std::io::ErrorKind::InvalidInput, "Missing required parameter")
                         )
-                        .into_boxed_dyn_error()
                     ));
                 }
             }

--- a/crates/mm-server/src/mcp/get_project_context.rs
+++ b/crates/mm-server/src/mcp/get_project_context.rs
@@ -25,11 +25,12 @@ impl GetProjectContextTool {
                 (Some(name), _) => ProjectFilter::Name(name),
                 (None, Some(repo)) => ProjectFilter::Repository(repo),
                 (None, None) => {
-                    return Err(rust_mcp_sdk::schema::schema_utils::CallToolError::new(
-                        crate::mcp::error::ToolError::with_source(
+                    return Err(rust_mcp_sdk::schema::schema_utils::CallToolError(
+                        crate::mcp::error::error_with_source(
                             "Either project_name or repository_name must be provided",
                             std::io::Error::new(std::io::ErrorKind::InvalidInput, "Missing required parameter")
                         )
+                        .into_boxed_dyn_error()
                     ));
                 }
             }

--- a/crates/mm-server/src/mcp/macros.rs
+++ b/crates/mm-server/src/mcp/macros.rs
@@ -59,13 +59,13 @@ macro_rules! generate_call_tool {
 
             let span = tracing::info_span!("call_tool");
             async move {
-                // Use ? to automatically convert CoreError to ToolError to CallToolError
+                // Convert core errors into CallToolError using anyhow
                 let result = $operation(ports, command.clone()).await
-                    .map_err(crate::mcp::error::ToolError::from)?;
+                    .map_err(crate::mcp::error::into_call_tool_error)?;
 
                 // Use ? again for JSON serialization errors
                 let json = serde_json::to_value(result)
-                    .map_err(crate::mcp::error::ToolError::from)?;
+                    .map_err(crate::mcp::error::into_call_tool_error)?;
 
                 // Return the final result
                 Ok(rust_mcp_sdk::schema::CallToolResult::text_content(json.to_string(), None))
@@ -94,9 +94,9 @@ macro_rules! generate_call_tool {
 
             let span = tracing::info_span!("call_tool");
             async move {
-                // Use ? to automatically convert CoreError to ToolError to CallToolError
+                // Convert core errors into CallToolError using anyhow
                 $operation(ports, command).await
-                    .map_err(crate::mcp::error::ToolError::from)?;
+                    .map_err(crate::mcp::error::into_call_tool_error)?;
 
                 // Return the success message
                 Ok(rust_mcp_sdk::schema::CallToolResult::text_content($success_msg.to_string(), None))

--- a/crates/mm-server/src/mcp/result_helpers.rs
+++ b/crates/mm-server/src/mcp/result_helpers.rs
@@ -1,12 +1,12 @@
 use rust_mcp_sdk::schema::{CallToolResult, schema_utils::CallToolError};
 use serde::Serialize;
-use crate::mcp::error::ToolError;
+use crate::mcp::error::into_call_tool_error;
 
 /// Convert a serializable value to a text content result
 pub fn to_json_result<T: Serialize>(value: T) -> Result<CallToolResult, CallToolError> {
     serde_json::to_value(value)
         .map(|json| CallToolResult::text_content(json.to_string(), None))
-        .map_err(|e| CallToolError::new(ToolError::from(e)))
+        .map_err(into_call_tool_error)
 }
 
 /// Handle an optional result, returning the value as JSON if present,


### PR DESCRIPTION
## Summary
- remove custom `ToolError` type
- introduce helpers using `anyhow::Error`
- use new `into_call_tool_error` conversion in macros
- update get_project_context and result helpers accordingly

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_685c481b14b88327adfdc72444af2a9f