### PR TITLE
Refactor logfile arg with required_if_eq_any

### DIFF
--- a/crates/mm-cli/src/main.rs
+++ b/crates/mm-cli/src/main.rs
@@ -23,11 +23,13 @@ struct Args {
         short = 'f',
         long,
         value_name = "FILE",
-        required_if_eq("log_level", "error"),
-        required_if_eq("log_level", "warn"),
-        required_if_eq("log_level", "info"),
-        required_if_eq("log_level", "debug"),
-        required_if_eq("log_level", "trace")
+        required_if_eq_any([
+            ("log_level", "error"),
+            ("log_level", "warn"),
+            ("log_level", "info"),
+            ("log_level", "debug"),
+            ("log_level", "trace"),
+        ])
     )]
     logfile: Option<PathBuf>,
 


### PR DESCRIPTION
## Summary
- refactor CLI arg validation
- replace multiple `required_if_eq` with a single `required_if_eq_any`

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_685cac93f5848327be48ac177f596c99