### PR TITLE
Improve task dependencies

### DIFF
--- a/crates/mm-core/src/operations/memory/mod.rs
+++ b/crates/mm-core/src/operations/memory/mod.rs
@@ -47,7 +47,7 @@ pub use list_projects::{ListProjectsCommand, ListProjectsResult, list_projects};
 pub use projects::{ProjectContext, ProjectProperties, ProjectStatus, ProjectType};
 pub use tasks::{
     CreateTasksCommand, CreateTasksResult, DeleteTaskCommand, DeleteTaskResult, GetTaskCommand,
-    GetTaskResult, Priority, TaskProperties, TaskStatus, TaskType, UpdateTaskCommand,
+    GetTaskResult, Priority, TaskInput, TaskProperties, TaskStatus, TaskType, UpdateTaskCommand,
     UpdateTaskResult, create_tasks, delete_task, get_task, update_task,
 };
 pub use update_entity::{UpdateEntityCommand, UpdateEntityResult, update_entity};

--- a/crates/mm-core/src/operations/memory/tasks/create_tasks.rs
+++ b/crates/mm-core/src/operations/memory/tasks/create_tasks.rs
@@ -4,15 +4,21 @@ use crate::error::{CoreError, CoreResult};
 use crate::ports::Ports;
 use mm_git::GitRepository;
 use mm_memory::MemoryRepository;
-use mm_memory::{MemoryEntity, MemoryRelationship};
+use mm_memory::{MemoryEntity, MemoryRelationship, ValidationError, ValidationErrorKind};
 use std::collections::HashMap;
 use tracing::instrument;
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+pub struct TaskInput {
+    pub task: MemoryEntity<TaskProperties>,
+    #[serde(default)]
+    pub depends_on: Vec<String>,
+}
+
 #[derive(Debug, Clone)]
 pub struct CreateTasksCommand {
-    pub tasks: Vec<MemoryEntity<TaskProperties>>,
+    pub tasks: Vec<TaskInput>,
     pub project_name: Option<String>,
-    pub depends_on: Vec<String>,
 }
 
 pub type CreateTasksResult<E> = CoreResult<(), E>;
@@ -37,26 +43,57 @@ where
     };
 
     let tasks = command.tasks;
-    let depends_on = command.depends_on;
-    let task_names: Vec<String> = tasks.iter().map(|t| t.name.clone()).collect();
+    let new_names: std::collections::HashSet<String> =
+        tasks.iter().map(|t| t.task.name.clone()).collect();
 
-    // Create the task entity
-    handle_batch_result(|| ports.memory_service.create_entities_typed(&tasks)).await?;
+    // Validate dependencies
+    let mut validation_errors = Vec::new();
+    for task in &tasks {
+        if task.depends_on.iter().any(|d| d == &task.task.name) {
+            validation_errors.push((
+                task.task.name.clone(),
+                ValidationError(vec![ValidationErrorKind::SelfDependency(
+                    task.task.name.clone(),
+                )]),
+            ));
+        }
+        for dep in &task.depends_on {
+            if dep != &task.task.name
+                && !new_names.contains(dep)
+                && ports
+                    .memory_service
+                    .find_entity_by_name(dep)
+                    .await?
+                    .is_none()
+            {
+                validation_errors.push((
+                    task.task.name.clone(),
+                    ValidationError(vec![ValidationErrorKind::DependencyNotFound(dep.clone())]),
+                ));
+            }
+        }
+    }
+    if !validation_errors.is_empty() {
+        return Err(CoreError::BatchValidation(validation_errors));
+    }
 
-    let mut relationships: Vec<MemoryRelationship> = task_names
-        .iter()
-        .map(|task_name| MemoryRelationship {
+    // Create the task entities
+    let entities: Vec<MemoryEntity<TaskProperties>> =
+        tasks.iter().map(|t| t.task.clone()).collect();
+    handle_batch_result(|| ports.memory_service.create_entities_typed(&entities)).await?;
+
+    let mut relationships: Vec<MemoryRelationship> = Vec::new();
+    for task in &tasks {
+        relationships.push(MemoryRelationship {
             from: project_name.clone(),
-            to: task_name.clone(),
+            to: task.task.name.clone(),
             name: "contains".to_string(),
             properties: HashMap::default(),
-        })
-        .collect();
+        });
 
-    for task_name in &task_names {
-        for dependency in &depends_on {
+        for dependency in &task.depends_on {
             relationships.push(MemoryRelationship {
-                from: task_name.clone(),
+                from: task.task.name.clone(),
                 to: dependency.clone(),
                 name: "depends_on".to_string(),
                 properties: HashMap::default(),
@@ -72,7 +109,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mm_git::repository::MockGitRepository;
     use mm_memory::labels::TASK_LABEL;
     use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository, ValidationErrorKind};
     use std::collections::HashSet;
@@ -97,18 +133,20 @@ mod tests {
                 ..MemoryConfig::default()
             },
         );
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
 
         let cmd = CreateTasksCommand {
-            tasks: vec![MemoryEntity::<TaskProperties> {
-                name: "task:1".into(),
-                labels: vec![TASK_LABEL.to_string()],
-                ..Default::default()
+            tasks: vec![TaskInput {
+                task: MemoryEntity::<TaskProperties> {
+                    name: "task:1".into(),
+                    labels: vec![TASK_LABEL.to_string()],
+                    ..Default::default()
+                },
+                depends_on: Vec::new(),
             }],
             project_name: None,
-            depends_on: Vec::new(),
         };
 
         let res = create_tasks(&ports, cmd).await;
@@ -118,6 +156,15 @@ mod tests {
     #[tokio::test]
     async fn test_create_tasks_with_dependencies() {
         let mut mock = MockMemoryRepository::new();
+        mock.expect_find_entity_by_name()
+            .with(mockall::predicate::eq("task:1"))
+            .return_once(|_| {
+                Ok(Some(MemoryEntity {
+                    name: "task:1".into(),
+                    labels: vec![TASK_LABEL.to_string()],
+                    ..Default::default()
+                }))
+            });
         mock.expect_create_entities()
             .withf(|ents| ents.len() == 1 && ents[0].name == "task:2")
             .returning(|_| Ok(()));
@@ -142,18 +189,20 @@ mod tests {
                 ..MemoryConfig::default()
             },
         );
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
 
         let cmd = CreateTasksCommand {
-            tasks: vec![MemoryEntity::<TaskProperties> {
-                name: "task:2".into(),
-                labels: vec![TASK_LABEL.to_string()],
-                ..Default::default()
+            tasks: vec![TaskInput {
+                task: MemoryEntity::<TaskProperties> {
+                    name: "task:2".into(),
+                    labels: vec![TASK_LABEL.to_string()],
+                    ..Default::default()
+                },
+                depends_on: vec!["task:1".into()],
             }],
             project_name: None,
-            depends_on: vec!["task:1".into()],
         };
 
         let res = create_tasks(&ports, cmd).await;
@@ -167,18 +216,20 @@ mod tests {
         mock.expect_create_relationships().never();
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
 
         let cmd = CreateTasksCommand {
-            tasks: vec![MemoryEntity::<TaskProperties> {
-                name: "task:1".into(),
-                labels: vec![TASK_LABEL.to_string()],
-                ..Default::default()
+            tasks: vec![TaskInput {
+                task: MemoryEntity::<TaskProperties> {
+                    name: "task:1".into(),
+                    labels: vec![TASK_LABEL.to_string()],
+                    ..Default::default()
+                },
+                depends_on: Vec::new(),
             }],
             project_name: None,
-            depends_on: Vec::new(),
         };
 
         let res = create_tasks(&ports, cmd).await;
@@ -198,18 +249,20 @@ mod tests {
                 ..MemoryConfig::default()
             },
         );
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
 
         let cmd = CreateTasksCommand {
-            tasks: vec![MemoryEntity::<TaskProperties> {
-                name: String::new(),
-                labels: vec![TASK_LABEL.to_string()],
-                ..Default::default()
+            tasks: vec![TaskInput {
+                task: MemoryEntity::<TaskProperties> {
+                    name: String::new(),
+                    labels: vec![TASK_LABEL.to_string()],
+                    ..Default::default()
+                },
+                depends_on: Vec::new(),
             }],
             project_name: None,
-            depends_on: Vec::new(),
         };
 
         let res = create_tasks(&ports, cmd).await;
@@ -217,6 +270,170 @@ mod tests {
             res,
             Err(CoreError::BatchValidation(ref errs))
                 if errs.iter().any(|(_, e)| e.0.contains(&ValidationErrorKind::EmptyEntityName))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_create_tasks_self_dependency() {
+        let mut mock = MockMemoryRepository::new();
+        mock.expect_create_entities().never();
+        mock.expect_create_relationships().never();
+
+        let service = MemoryService::new(
+            mock,
+            MemoryConfig {
+                default_project: Some("proj".into()),
+                additional_relationships: std::iter::once("depends_on".to_string())
+                    .collect::<HashSet<_>>(),
+                ..MemoryConfig::default()
+            },
+        );
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
+
+        let cmd = CreateTasksCommand {
+            tasks: vec![TaskInput {
+                task: MemoryEntity::<TaskProperties> {
+                    name: "task:1".into(),
+                    labels: vec![TASK_LABEL.to_string()],
+                    ..Default::default()
+                },
+                depends_on: vec!["task:1".into()],
+            }],
+            project_name: None,
+        };
+
+        let res = create_tasks(&ports, cmd).await;
+        assert!(
+            matches!(res, Err(CoreError::BatchValidation(ref errs)) if errs
+            .iter()
+            .any(|(n, e)| {
+                n == "task:1" && e.0.iter().any(|k| matches!(k, ValidationErrorKind::SelfDependency(_)))
+            }))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_task_specific_dependencies() {
+        let mut mock = MockMemoryRepository::new();
+        mock.expect_find_entity_by_name()
+            .with(mockall::predicate::eq("other:task"))
+            .returning(|_| {
+                Ok(Some(MemoryEntity {
+                    name: "other:task".into(),
+                    labels: vec![TASK_LABEL.to_string()],
+                    ..Default::default()
+                }))
+            });
+        mock.expect_create_entities()
+            .withf(|ents| {
+                ents.len() == 2
+                    && ents.iter().any(|e| e.name == "task:1")
+                    && ents.iter().any(|e| e.name == "task:2")
+            })
+            .returning(|_| Ok(()));
+        mock.expect_create_relationships()
+            .withf(|rels| {
+                rels.len() == 5
+                    && rels
+                        .iter()
+                        .any(|r| r.from == "proj" && r.to == "task:1" && r.name == "contains")
+                    && rels
+                        .iter()
+                        .any(|r| r.from == "proj" && r.to == "task:2" && r.name == "contains")
+                    && rels
+                        .iter()
+                        .any(|r| r.from == "task:1" && r.to == "task:2" && r.name == "depends_on")
+                    && rels.iter().any(|r| {
+                        r.from == "task:1" && r.to == "other:task" && r.name == "depends_on"
+                    })
+                    && rels.iter().any(|r| {
+                        r.from == "task:2" && r.to == "other:task" && r.name == "depends_on"
+                    })
+            })
+            .returning(|_| Ok(()));
+
+        let service = MemoryService::new(
+            mock,
+            MemoryConfig {
+                default_project: Some("proj".into()),
+                additional_relationships: std::iter::once("depends_on".to_string())
+                    .collect::<HashSet<_>>(),
+                ..MemoryConfig::default()
+            },
+        );
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
+
+        let cmd = CreateTasksCommand {
+            tasks: vec![
+                TaskInput {
+                    task: MemoryEntity::<TaskProperties> {
+                        name: "task:1".into(),
+                        labels: vec![TASK_LABEL.to_string()],
+                        ..Default::default()
+                    },
+                    depends_on: vec!["task:2".into(), "other:task".into()],
+                },
+                TaskInput {
+                    task: MemoryEntity::<TaskProperties> {
+                        name: "task:2".into(),
+                        labels: vec![TASK_LABEL.to_string()],
+                        ..Default::default()
+                    },
+                    depends_on: vec!["other:task".into()],
+                },
+            ],
+            project_name: None,
+        };
+
+        let res = create_tasks(&ports, cmd).await;
+        assert!(res.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_dependency_must_exist() {
+        let mut mock = MockMemoryRepository::new();
+        mock.expect_find_entity_by_name()
+            .with(mockall::predicate::eq("missing:task"))
+            .returning(|_| Ok(None));
+        mock.expect_create_entities().never();
+        mock.expect_create_relationships().never();
+
+        let service = MemoryService::new(
+            mock,
+            MemoryConfig {
+                default_project: Some("proj".into()),
+                additional_relationships: std::iter::once("depends_on".to_string())
+                    .collect::<HashSet<_>>(),
+                ..MemoryConfig::default()
+            },
+        );
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
+
+        let cmd = CreateTasksCommand {
+            tasks: vec![TaskInput {
+                task: MemoryEntity::<TaskProperties> {
+                    name: "task:1".into(),
+                    labels: vec![TASK_LABEL.to_string()],
+                    ..Default::default()
+                },
+                depends_on: vec!["missing:task".into()],
+            }],
+            project_name: None,
+        };
+
+        let res = create_tasks(&ports, cmd).await;
+        assert!(matches!(
+            res,
+            Err(CoreError::BatchValidation(ref errs))
+                if errs.iter().any(|(n, e)| {
+                    n == "task:1" && e.0.contains(&ValidationErrorKind::DependencyNotFound("missing:task".into()))
+                })
         ));
     }
 }

--- a/crates/mm-core/src/operations/memory/tasks/mod.rs
+++ b/crates/mm-core/src/operations/memory/tasks/mod.rs
@@ -5,7 +5,7 @@ mod delete_task;
 mod get_task;
 mod update_task;
 
-pub use create_tasks::{CreateTasksCommand, CreateTasksResult, create_tasks};
+pub use create_tasks::{CreateTasksCommand, CreateTasksResult, TaskInput, create_tasks};
 pub use delete_task::{DeleteTaskCommand, DeleteTaskResult, delete_task};
 pub use get_task::{GetTaskCommand, GetTaskResult, get_task};
 pub use types::{Priority, TaskProperties, TaskStatus, TaskType};

--- a/crates/mm-memory/src/validation_error.rs
+++ b/crates/mm-memory/src/validation_error.rs
@@ -30,6 +30,14 @@ pub enum ValidationErrorKind {
     /// Error when multiple operations are specified for the same field
     #[error("Conflicting operations for {0}")]
     ConflictingOperations(&'static str),
+
+    /// Error when a task depends on itself
+    #[error("Task '{0}' cannot depend on itself")]
+    SelfDependency(String),
+
+    /// Error when a task depends on a non-existent task
+    #[error("Dependency '{0}' not found")]
+    DependencyNotFound(String),
 }
 
 /// Collection of validation errors


### PR DESCRIPTION
## Summary
- reject non-existent task dependencies and add new validation error
- extend create_tasks logic to check dependency existence
- expand unit tests for per-task dependencies and missing task errors
- move server test imports inside tests module
- refactor create_tasks tests to use `Ports::noop`
- remove unused git service mocks from tests

## Testing
- `just validate`


------
https://chatgpt.com/codex/tasks/task_e_685cbdae32e48327a27a4eda809c439b