### PR TITLE
Add config validation command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,6 +1475,7 @@ dependencies = [
  "clap",
  "mm-git-git2",
  "mm-server",
+ "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/mm-cli/Cargo.toml
+++ b/crates/mm-cli/Cargo.toml
@@ -13,3 +13,4 @@ tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 anyhow = "1.0"
+serde_json = { workspace = true }


### PR DESCRIPTION
## Summary
- add a `config validate` subcommand to `mm-cli`
- share config initialization with `mm-server`
- print validation result or debug info
- allow showing loaded config with `--show`
- use workspace `serde_json` dependency
- keep `main` signature unchanged

## Testing
- `cargo check -p mm-cli`
- `just validate`


------
https://chatgpt.com/codex/tasks/task_e_685cd07ea600832789b7a4f9f167bd26