### PR TITLE
Refactor tests to use minimal Ports setup

### DIFF
--- a/crates/mm-core/src/operations/memory/create_entity.rs
+++ b/crates/mm-core/src/operations/memory/create_entity.rs
@@ -43,7 +43,6 @@ where
 mod tests {
     use super::*;
     use crate::error::CoreError;
-    use mm_git::repository::MockGitRepository;
     use mm_memory::ValidationErrorKind;
     use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
     use std::sync::Arc;
@@ -65,9 +64,9 @@ mod tests {
                 ..MemoryConfig::default()
             },
         );
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
 
         let command = CreateEntitiesCommand {
             entities: vec![MemoryEntity {
@@ -95,9 +94,9 @@ mod tests {
                 ..MemoryConfig::default()
             },
         );
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
 
         let command = CreateEntitiesCommand {
             entities: vec![MemoryEntity {
@@ -133,9 +132,9 @@ mod tests {
                 ..MemoryConfig::default()
             },
         );
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
 
         let command = CreateEntitiesCommand {
             entities: vec![MemoryEntity {
@@ -164,9 +163,9 @@ mod tests {
                 ..MemoryConfig::default()
             },
         );
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
 
         let command = CreateEntitiesCommand {
             entities: vec![

--- a/crates/mm-core/src/operations/memory/create_relationship.rs
+++ b/crates/mm-core/src/operations/memory/create_relationship.rs
@@ -35,7 +35,6 @@ where
 mod tests {
     use super::*;
     use crate::error::CoreError;
-    use mm_git::repository::MockGitRepository;
     use mm_memory::ValidationErrorKind;
     use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
     use std::collections::HashMap;
@@ -49,9 +48,9 @@ mod tests {
             .returning(|_| Ok(()));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
 
         let command = CreateRelationshipsCommand {
             relationships: vec![MemoryRelationship {
@@ -71,9 +70,9 @@ mod tests {
         let mut mock = MockMemoryRepository::new();
         mock.expect_create_relationships().never();
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
 
         let command = CreateRelationshipsCommand {
             relationships: vec![MemoryRelationship {
@@ -96,9 +95,9 @@ mod tests {
         let mut mock = MockMemoryRepository::new();
         mock.expect_create_relationships().never();
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
 
         let command = CreateRelationshipsCommand {
             relationships: vec![MemoryRelationship {
@@ -121,9 +120,9 @@ mod tests {
         let mut mock = MockMemoryRepository::new();
         mock.expect_create_relationships().never();
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
 
         let command = CreateRelationshipsCommand {
             relationships: vec![MemoryRelationship {
@@ -147,9 +146,9 @@ mod tests {
         mock.expect_create_relationships().never();
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
 
         let command = CreateRelationshipsCommand {
             relationships: vec![

--- a/crates/mm-core/src/operations/memory/get_entity.rs
+++ b/crates/mm-core/src/operations/memory/get_entity.rs
@@ -14,7 +14,6 @@ generate_get_wrapper!(
 mod tests {
     use super::*;
     use crate::ports::Ports;
-    use mm_git::repository::MockGitRepository;
     use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository, ValidationErrorKind};
     use mockall::predicate::*;
     use std::sync::Arc;
@@ -34,9 +33,9 @@ mod tests {
             .returning(move |_| Ok(Some(entity.clone())));
 
         let service = MemoryService::new(mock_repo, MemoryConfig::default());
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
         let command = GetEntityCommand {
             name: "test:entity".to_string(),
         };
@@ -51,9 +50,9 @@ mod tests {
         let mut mock_repo = MockMemoryRepository::new();
         mock_repo.expect_find_entity_by_name().never();
         let service = MemoryService::new(mock_repo, MemoryConfig::default());
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
 
         let command = GetEntityCommand {
             name: "".to_string(),
@@ -77,9 +76,9 @@ mod tests {
             .returning(|_| Err(MemoryError::query_error("db error")));
 
         let service = MemoryService::new(mock_repo, MemoryConfig::default());
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
 
         let command = GetEntityCommand {
             name: "test:entity".to_string(),
@@ -99,9 +98,9 @@ mod tests {
             .returning(|_| Ok(None));
 
         let service = MemoryService::new(mock_repo, MemoryConfig::default());
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
 
         let command = GetEntityCommand {
             name: "missing:entity".to_string(),
@@ -125,9 +124,9 @@ mod tests {
                 .withf(move |n| n == name_clone)
                 .returning(|_| Ok(None));
             let service = MemoryService::new(mock_repo, MemoryConfig::default());
-            let git_repo = MockGitRepository::new();
-            let git_service = mm_git::GitService::new(git_repo);
-            let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+            let ports = Ports::noop().with(|p| {
+                p.memory_service = Arc::new(service);
+            });
             let command = GetEntityCommand { name };
             let result = rt.block_on(get_entity(&ports, command));
             assert!(result.is_ok());
@@ -141,9 +140,9 @@ mod tests {
             let mut mock_repo = MockMemoryRepository::new();
             mock_repo.expect_find_entity_by_name().never();
             let service = MemoryService::new(mock_repo, MemoryConfig::default());
-            let git_repo = MockGitRepository::new();
-            let git_service = mm_git::GitService::new(git_repo);
-            let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+            let ports = Ports::noop().with(|p| {
+                p.memory_service = Arc::new(service);
+            });
             let command = GetEntityCommand {
                 name: String::default(),
             };

--- a/crates/mm-core/src/operations/memory/list_projects.rs
+++ b/crates/mm-core/src/operations/memory/list_projects.rs
@@ -55,7 +55,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mm_git::repository::MockGitRepository;
     use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
     use mockall::predicate::*;
     use std::collections::HashMap;
@@ -93,9 +92,9 @@ mod tests {
             .returning(move |_, _, _| Ok(vec![project1.clone(), project2.clone()]));
 
         let service = MemoryService::new(mock_repo, MemoryConfig::default());
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
 
         let command = ListProjectsCommand { name_filter: None };
 
@@ -138,9 +137,9 @@ mod tests {
             .returning(move |_, _, _| Ok(vec![project1.clone(), project2.clone()]));
 
         let service = MemoryService::new(mock_repo, MemoryConfig::default());
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
 
         let command = ListProjectsCommand {
             name_filter: Some("flakes".to_string()),
@@ -168,9 +167,9 @@ mod tests {
             .returning(move |_, _, _| Ok(vec![]));
 
         let service = MemoryService::new(mock_repo, MemoryConfig::default());
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
 
         let command = ListProjectsCommand { name_filter: None };
 

--- a/crates/mm-core/src/operations/memory/tasks/delete_task.rs
+++ b/crates/mm-core/src/operations/memory/tasks/delete_task.rs
@@ -7,7 +7,6 @@ generate_delete_wrapper!(DeleteTaskCommand, delete_task, DeleteTaskResult);
 mod tests {
     use super::*;
     use crate::ports::Ports;
-    use mm_git::repository::MockGitRepository;
     use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
     use std::sync::Arc;
 
@@ -18,9 +17,9 @@ mod tests {
             .withf(|n| n.len() == 1 && n[0] == "task:1")
             .returning(|_| Ok(()));
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
         let cmd = DeleteTaskCommand {
             name: "task:1".into(),
         };
@@ -33,9 +32,9 @@ mod tests {
         let mut mock = MockMemoryRepository::new();
         mock.expect_delete_entities().never();
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
         let cmd = DeleteTaskCommand {
             name: String::new(),
         };

--- a/crates/mm-core/src/operations/memory/tasks/get_task.rs
+++ b/crates/mm-core/src/operations/memory/tasks/get_task.rs
@@ -10,7 +10,6 @@ generate_get_wrapper!(GetTaskCommand, get_task, GetTaskResult, TaskProperties);
 mod tests {
     use super::*;
     use crate::ports::Ports;
-    use mm_git::repository::MockGitRepository;
     use mm_memory::labels::TASK_LABEL;
     use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
     use mockall::predicate::*;
@@ -29,9 +28,9 @@ mod tests {
             .returning(move |_| Ok(Some(entity.clone())));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
 
         let cmd = GetTaskCommand {
             name: "task:1".into(),
@@ -45,9 +44,9 @@ mod tests {
         let mut mock = MockMemoryRepository::new();
         mock.expect_find_entity_by_name().never();
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
 
         let cmd = GetTaskCommand {
             name: String::new(),

--- a/crates/mm-core/src/operations/memory/tasks/update_task.rs
+++ b/crates/mm-core/src/operations/memory/tasks/update_task.rs
@@ -9,7 +9,6 @@ generate_update_wrapper!(UpdateTaskCommand, update_task, UpdateTaskResult);
 mod tests {
     use super::*;
     use crate::ports::Ports;
-    use mm_git::repository::MockGitRepository;
     use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
     use std::sync::Arc;
 
@@ -21,9 +20,9 @@ mod tests {
             .returning(|_, _| Ok(()));
 
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
 
         let cmd = UpdateTaskCommand {
             name: "task:1".into(),
@@ -38,9 +37,9 @@ mod tests {
         let mut mock = MockMemoryRepository::new();
         mock.expect_update_entity().never();
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
         let cmd = UpdateTaskCommand {
             name: String::new(),
             update: EntityUpdate::default(),

--- a/crates/mm-core/src/operations/memory/update_entity.rs
+++ b/crates/mm-core/src/operations/memory/update_entity.rs
@@ -9,7 +9,6 @@ generate_update_wrapper!(UpdateEntityCommand, update_entity, UpdateEntityResult)
 mod tests {
     use super::*;
     use crate::ports::Ports;
-    use mm_git::repository::MockGitRepository;
     use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
     use std::sync::Arc;
 
@@ -20,9 +19,9 @@ mod tests {
             .withf(|n, _| n == "test:entity")
             .returning(|_, _| Ok(()));
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
         let cmd = UpdateEntityCommand {
             name: "test:entity".into(),
             update: EntityUpdate::default(),
@@ -36,9 +35,9 @@ mod tests {
         let mut mock = MockMemoryRepository::new();
         mock.expect_update_entity().never();
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
         let cmd = UpdateEntityCommand {
             name: "".into(),
             update: EntityUpdate::default(),

--- a/crates/mm-core/src/operations/memory/update_relationship.rs
+++ b/crates/mm-core/src/operations/memory/update_relationship.rs
@@ -39,7 +39,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mm_git::repository::MockGitRepository;
     use mm_memory::{MemoryConfig, MemoryService, MockMemoryRepository};
     use std::sync::Arc;
 
@@ -50,9 +49,9 @@ mod tests {
             .withf(|f, t, n, _| f == "a" && t == "b" && n == "rel")
             .returning(|_, _, _, _| Ok(()));
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
         let cmd = UpdateRelationshipCommand {
             from: "a".into(),
             to: "b".into(),
@@ -68,9 +67,9 @@ mod tests {
         let mut mock = MockMemoryRepository::new();
         mock.expect_update_relationship().never();
         let service = MemoryService::new(mock, MemoryConfig::default());
-        let git_repo = MockGitRepository::new();
-        let git_service = mm_git::GitService::new(git_repo);
-        let ports = Ports::new(Arc::new(service), Arc::new(git_service));
+        let ports = Ports::noop().with(|p| {
+            p.memory_service = Arc::new(service);
+        });
         let cmd = UpdateRelationshipCommand {
             from: "".into(),
             to: "b".into(),


### PR DESCRIPTION
## Summary
- cleanup tests to avoid setting unused git service mocks
- use `Ports::noop().with()` to only set needed services

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_685ccdc460b4832794fd20c49f1170b7