### PR TITLE
Expose find_related_entities tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The `memory://` scheme is dynamic: any entity name can be requested. The server 
 | `delete_relationships` | Delete relationships between entities |
 | `find_entities_by_labels` | Find entities with specific labels |
 | `find_relationships` | Find relationships between entities |
+| `find_related_entities` | Find entities related to another entity (supports `depth` parameter) |
 | `create_tasks` | Create task entities |
 | `get_task` | Retrieve a task by name |
 | `update_task` | Update a task |
@@ -33,6 +34,9 @@ The `memory://` scheme is dynamic: any entity name can be requested. The server 
 | `list_projects` | List known projects |
 | `update_entity` | Update an entity |
 | `update_relationship` | Update a relationship |
+
+The `find_related_entities` tool accepts a `depth` parameter controlling how many
+relationship hops to follow. Depth values must be between 1 and 5.
 
 ## Project Structure
 

--- a/crates/mm-core/src/operations/memory/find_related_entities.rs
+++ b/crates/mm-core/src/operations/memory/find_related_entities.rs
@@ -1,0 +1,126 @@
+use crate::error::{CoreError, CoreResult};
+use crate::ports::Ports;
+use crate::validate_name;
+use mm_git::GitRepository;
+use mm_memory::{MemoryEntity, MemoryRepository, RelationshipDirection};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tracing::instrument;
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct FindRelatedEntitiesCommand {
+    pub name: String,
+    pub relationship: Option<String>,
+    pub direction: Option<RelationshipDirection>,
+    pub depth: u32,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct FindRelatedEntitiesResult {
+    pub entities: Vec<MemoryEntity>,
+}
+
+pub type FindRelatedEntitiesResultType<E> = CoreResult<FindRelatedEntitiesResult, E>;
+
+#[instrument(skip(ports), fields(name = %command.name, depth = command.depth))]
+pub async fn find_related_entities<M, G>(
+    ports: &Ports<M, G>,
+    command: FindRelatedEntitiesCommand,
+) -> FindRelatedEntitiesResultType<M::Error>
+where
+    M: MemoryRepository + Send + Sync,
+    G: GitRepository + Send + Sync,
+    M::Error: std::error::Error + Send + Sync + 'static,
+    G::Error: std::error::Error + Send + Sync + 'static,
+{
+    validate_name!(command.name);
+
+    let entities = ports
+        .memory_service
+        .find_related_entities(
+            &command.name,
+            command.relationship.clone(),
+            command.direction,
+            command.depth,
+        )
+        .await
+        .map_err(CoreError::from)?;
+
+    Ok(FindRelatedEntitiesResult { entities })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ports::Ports;
+    use mm_memory::{MemoryConfig, MemoryError, MemoryService, MockMemoryRepository};
+    use mockall::predicate::*;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_find_related_entities_success() {
+        let mut mock = MockMemoryRepository::new();
+        let expected = vec![MemoryEntity {
+            name: "b".into(),
+            ..Default::default()
+        }];
+        mock.expect_find_related_entities()
+            .with(
+                eq("a"),
+                eq(Some("rel".to_string())),
+                eq(Some(RelationshipDirection::Outgoing)),
+                eq(2u32),
+            )
+            .returning(move |_, _, _, _| Ok(expected.clone()));
+
+        let service = MemoryService::new(mock, MemoryConfig::default());
+        let ports = Ports::noop().with(|p| p.memory_service = Arc::new(service));
+
+        let cmd = FindRelatedEntitiesCommand {
+            name: "a".into(),
+            relationship: Some("rel".into()),
+            direction: Some(RelationshipDirection::Outgoing),
+            depth: 2,
+        };
+
+        let res = find_related_entities(&ports, cmd).await.unwrap();
+        assert_eq!(res.entities.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_find_related_entities_empty_name() {
+        let mut mock = MockMemoryRepository::new();
+        mock.expect_find_related_entities().never();
+        let service = MemoryService::new(mock, MemoryConfig::default());
+        let ports = Ports::noop().with(|p| p.memory_service = Arc::new(service));
+
+        let cmd = FindRelatedEntitiesCommand {
+            name: "".into(),
+            relationship: None,
+            direction: None,
+            depth: 1,
+        };
+
+        let res = find_related_entities(&ports, cmd).await;
+        assert!(matches!(res, Err(CoreError::Validation(_))));
+    }
+
+    #[tokio::test]
+    async fn test_find_related_entities_repo_error() {
+        let mut mock = MockMemoryRepository::new();
+        mock.expect_find_related_entities()
+            .returning(|_, _, _, _| Err(MemoryError::query_error("fail")));
+        let service = MemoryService::new(mock, MemoryConfig::default());
+        let ports = Ports::noop().with(|p| p.memory_service = Arc::new(service));
+
+        let cmd = FindRelatedEntitiesCommand {
+            name: "a".into(),
+            relationship: None,
+            direction: None,
+            depth: 1,
+        };
+
+        let res = find_related_entities(&ports, cmd).await;
+        assert!(matches!(res, Err(CoreError::Memory(_))));
+    }
+}

--- a/crates/mm-core/src/operations/memory/mod.rs
+++ b/crates/mm-core/src/operations/memory/mod.rs
@@ -14,6 +14,7 @@ pub mod create_relationship;
 pub mod delete_entities;
 pub mod delete_relationships;
 pub mod find_entities_by_labels;
+pub mod find_related_entities;
 pub mod find_relationships;
 pub mod get_entity;
 pub mod get_project_context;
@@ -32,6 +33,10 @@ pub use delete_relationships::{
 pub use find_entities_by_labels::{
     FindEntitiesByLabelsCommand, FindEntitiesByLabelsResult, FindEntitiesByLabelsResultType,
     find_entities_by_labels,
+};
+pub use find_related_entities::{
+    FindRelatedEntitiesCommand, FindRelatedEntitiesResult, FindRelatedEntitiesResultType,
+    find_related_entities,
 };
 pub use find_relationships::{
     FindRelationshipsCommand, FindRelationshipsResult, FindRelationshipsResultType,

--- a/crates/mm-server/src/mcp/find_related_entities.rs
+++ b/crates/mm-server/src/mcp/find_related_entities.rs
@@ -1,0 +1,71 @@
+use mm_core::operations::memory::{FindRelatedEntitiesCommand, find_related_entities};
+use mm_memory::RelationshipDirection;
+use mm_utils::IntoJsonSchema;
+use rust_mcp_sdk::macros::mcp_tool;
+use serde::{Deserialize, Serialize};
+
+#[mcp_tool(
+    name = "find_related_entities",
+    description = "Find entities related to a given entity"
+)]
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct FindRelatedEntitiesTool {
+    pub name: String,
+    pub relationship: Option<String>,
+    pub direction: Option<RelationshipDirection>,
+    pub depth: u32,
+}
+
+impl FindRelatedEntitiesTool {
+    generate_call_tool!(
+        self,
+        FindRelatedEntitiesCommand {
+            name,
+            relationship,
+            direction,
+            depth
+        },
+        find_related_entities
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mm_core::Ports;
+    use mm_memory::{MemoryConfig, MemoryEntity, MemoryService, MockMemoryRepository};
+    use mockall::predicate::*;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_call_tool_success() {
+        let mut mock = MockMemoryRepository::new();
+        mock.expect_find_related_entities()
+            .with(
+                eq("a"),
+                eq(Some("rel".to_string())),
+                eq(Some(RelationshipDirection::Outgoing)),
+                eq(2u32),
+            )
+            .returning(|_, _, _, _| Ok(vec![MemoryEntity::default()]));
+        let service = MemoryService::new(mock, MemoryConfig::default());
+        let ports = Ports::noop().with(|p| p.memory_service = Arc::new(service));
+
+        let tool = FindRelatedEntitiesTool {
+            name: "a".into(),
+            relationship: Some("rel".into()),
+            direction: Some(RelationshipDirection::Outgoing),
+            depth: 2,
+        };
+
+        let result = tool.call_tool(&ports).await.expect("tool should succeed");
+        let text = result.content[0].as_text_content().unwrap().text.clone();
+        assert!(text.contains("entities"));
+    }
+
+    #[test]
+    fn test_schema_has_no_refs() {
+        use crate::mcp::tests::assert_no_defs;
+        assert_no_defs::<FindRelatedEntitiesTool>();
+    }
+}

--- a/crates/mm-server/src/mcp/mod.rs
+++ b/crates/mm-server/src/mcp/mod.rs
@@ -8,6 +8,7 @@ pub mod delete_relationships;
 pub mod delete_task;
 pub mod error;
 pub mod find_entities_by_labels;
+pub mod find_related_entities;
 pub mod find_relationships;
 pub mod get_entity;
 pub mod get_git_status;
@@ -31,6 +32,7 @@ pub use delete_entities::DeleteEntitiesTool;
 pub use delete_relationships::DeleteRelationshipsTool;
 pub use delete_task::DeleteTaskTool;
 pub use find_entities_by_labels::FindEntitiesByLabelsTool;
+pub use find_related_entities::FindRelatedEntitiesTool;
 pub use find_relationships::FindRelationshipsTool;
 pub use get_entity::GetEntityTool;
 pub use get_git_status::GetGitStatusTool;
@@ -51,6 +53,7 @@ tool_box!(
         DeleteRelationshipsTool,
         FindEntitiesByLabelsTool,
         FindRelationshipsTool,
+        FindRelatedEntitiesTool,
         CreateTasksTool,
         GetTaskTool,
         UpdateTaskTool,
@@ -86,6 +89,7 @@ impl MMTools {
             MMTools::DeleteRelationshipsTool(tool) => tool.call_tool(ports).await,
             MMTools::FindEntitiesByLabelsTool(tool) => tool.call_tool(ports).await,
             MMTools::FindRelationshipsTool(tool) => tool.call_tool(ports).await,
+            MMTools::FindRelatedEntitiesTool(tool) => tool.call_tool(ports).await,
             MMTools::CreateTasksTool(tool) => tool.call_tool(ports).await,
             MMTools::GetTaskTool(tool) => tool.call_tool(ports).await,
             MMTools::UpdateTaskTool(tool) => tool.call_tool(ports).await,
@@ -108,6 +112,7 @@ impl MMTools {
             MMTools::DeleteRelationshipsTool(_) => DeleteRelationshipsTool::json_schema(),
             MMTools::FindEntitiesByLabelsTool(_) => FindEntitiesByLabelsTool::json_schema(),
             MMTools::FindRelationshipsTool(_) => FindRelationshipsTool::json_schema(),
+            MMTools::FindRelatedEntitiesTool(_) => FindRelatedEntitiesTool::json_schema(),
             MMTools::CreateTasksTool(_) => CreateTasksTool::json_schema(),
             MMTools::GetTaskTool(_) => GetTaskTool::json_schema(),
             MMTools::UpdateTaskTool(_) => UpdateTaskTool::json_schema(),


### PR DESCRIPTION
## Summary
- add `find_related_entities` core operation and server tool
- export the new tool from the MCP toolbox
- document the tool and explain `depth` parameter

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_685cdc5921588327b0b487be4579160a