### PR TITLE
Add get_graph_meta tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The `memory://` scheme is dynamic: any entity name can be requested. The server 
 | `delete_task` | Delete a task |
 | `get_entity` | Retrieve an entity by name |
 | `get_git_status` | Get Git status for a repository path |
+| `get_graph_meta` | List entities related to the memory graph root |
 | `get_project_context` | Retrieve context for a project |
 | `list_projects` | List known projects |
 | `update_entity` | Update an entity |
@@ -37,6 +38,9 @@ The `memory://` scheme is dynamic: any entity name can be requested. The server 
 
 The `find_related_entities` tool accepts a `depth` parameter controlling how many
 relationship hops to follow. Depth values must be between 1 and 5.
+
+The `get_graph_meta` tool returns entities outbound from the `tech:tool:memory_graph` node.
+It traverses the graph with a fixed depth of `5` and accepts an optional `relationship` filter.
 
 ## Project Structure
 

--- a/crates/mm-core/src/operations/memory/get_graph_meta.rs
+++ b/crates/mm-core/src/operations/memory/get_graph_meta.rs
@@ -1,0 +1,96 @@
+use crate::error::{CoreError, CoreResult};
+use crate::ports::Ports;
+use mm_git::GitRepository;
+use mm_memory::{MemoryEntity, MemoryRepository, RelationshipDirection};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tracing::instrument;
+
+/// Name of the root memory graph entity
+pub const GRAPH_ROOT: &str = "tech:tool:memory_graph";
+/// Default traversal depth
+const DEPTH: u32 = 5;
+
+/// Command for retrieving graph metadata
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct GetGraphMetaCommand {
+    /// Optional relationship type filter
+    pub relationship: Option<String>,
+}
+
+/// Result containing entities related to the memory graph root
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct GetGraphMetaResult {
+    /// Entities found
+    pub entities: Vec<MemoryEntity>,
+}
+
+pub type GetGraphMetaResultType<E> = CoreResult<GetGraphMetaResult, E>;
+
+#[instrument(skip(ports), err)]
+pub async fn get_graph_meta<M, G>(
+    ports: &Ports<M, G>,
+    command: GetGraphMetaCommand,
+) -> GetGraphMetaResultType<M::Error>
+where
+    M: MemoryRepository + Send + Sync,
+    G: GitRepository + Send + Sync,
+    M::Error: std::error::Error + Send + Sync + 'static,
+    G::Error: std::error::Error + Send + Sync + 'static,
+{
+    let entities = ports
+        .memory_service
+        .find_related_entities(
+            GRAPH_ROOT,
+            command.relationship.clone(),
+            Some(RelationshipDirection::Outgoing),
+            DEPTH,
+        )
+        .await
+        .map_err(CoreError::from)?;
+
+    Ok(GetGraphMetaResult { entities })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ports::Ports;
+    use mm_memory::{MemoryConfig, MemoryEntity, MemoryError, MemoryService, MockMemoryRepository};
+    use mockall::predicate::*;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_get_graph_meta_success() {
+        let mut mock = MockMemoryRepository::new();
+        mock.expect_find_related_entities()
+            .with(
+                eq(GRAPH_ROOT),
+                eq(Some("rel".to_string())),
+                eq(Some(RelationshipDirection::Outgoing)),
+                eq(DEPTH),
+            )
+            .returning(|_, _, _, _| Ok(vec![MemoryEntity::default()]));
+        let service = MemoryService::new(mock, MemoryConfig::default());
+        let ports = Ports::noop().with(|p| p.memory_service = Arc::new(service));
+
+        let cmd = GetGraphMetaCommand {
+            relationship: Some("rel".to_string()),
+        };
+        let result = get_graph_meta(&ports, cmd).await.unwrap();
+        assert_eq!(result.entities.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_get_graph_meta_repo_error() {
+        let mut mock = MockMemoryRepository::new();
+        mock.expect_find_related_entities()
+            .returning(|_, _, _, _| Err(MemoryError::query_error("fail")));
+        let service = MemoryService::new(mock, MemoryConfig::default());
+        let ports = Ports::noop().with(|p| p.memory_service = Arc::new(service));
+
+        let cmd = GetGraphMetaCommand { relationship: None };
+        let res = get_graph_meta(&ports, cmd).await;
+        assert!(matches!(res, Err(CoreError::Memory(_))));
+    }
+}

--- a/crates/mm-core/src/operations/memory/mod.rs
+++ b/crates/mm-core/src/operations/memory/mod.rs
@@ -17,6 +17,7 @@ pub mod find_entities_by_labels;
 pub mod find_related_entities;
 pub mod find_relationships;
 pub mod get_entity;
+pub mod get_graph_meta;
 pub mod get_project_context;
 pub mod list_projects;
 pub mod update_entity;
@@ -44,6 +45,9 @@ pub use find_relationships::{
 };
 pub use generic::{get_entity_generic, update_entity_generic};
 pub use get_entity::{GetEntityCommand, GetEntityResult, get_entity};
+pub use get_graph_meta::{
+    GRAPH_ROOT, GetGraphMetaCommand, GetGraphMetaResult, GetGraphMetaResultType, get_graph_meta,
+};
 pub use get_project_context::{
     GetProjectContextCommand, GetProjectContextResult, ProjectFilter, get_project_context,
 };

--- a/crates/mm-server/src/mcp/get_graph_meta.rs
+++ b/crates/mm-server/src/mcp/get_graph_meta.rs
@@ -1,0 +1,56 @@
+use mm_core::operations::memory::{GetGraphMetaCommand, get_graph_meta};
+use mm_utils::IntoJsonSchema;
+use rust_mcp_sdk::macros::mcp_tool;
+use serde::{Deserialize, Serialize};
+
+/// MCP tool for retrieving metadata about the memory graph root
+#[mcp_tool(
+    name = "get_graph_meta",
+    description = "Return entities related to the memory graph root"
+)]
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct GetGraphMetaTool {
+    /// Optional relationship type filter
+    pub relationship: Option<String>,
+}
+
+impl GetGraphMetaTool {
+    generate_call_tool!(self, GetGraphMetaCommand { relationship }, get_graph_meta);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mm_core::Ports;
+    use mm_memory::{
+        MemoryConfig, MemoryEntity, MemoryService, MockMemoryRepository, RelationshipDirection,
+    };
+    use mockall::predicate::*;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_call_tool_success() {
+        let mut mock = MockMemoryRepository::new();
+        mock.expect_find_related_entities()
+            .with(
+                eq(mm_core::operations::memory::GRAPH_ROOT),
+                eq(None),
+                eq(Some(RelationshipDirection::Outgoing)),
+                eq(5u32),
+            )
+            .returning(|_, _, _, _| Ok(vec![MemoryEntity::default()]));
+        let service = MemoryService::new(mock, MemoryConfig::default());
+        let ports = Ports::noop().with(|p| p.memory_service = Arc::new(service));
+
+        let tool = GetGraphMetaTool { relationship: None };
+        let result = tool.call_tool(&ports).await.expect("tool should succeed");
+        let text = result.content[0].as_text_content().unwrap().text.clone();
+        assert!(text.contains("entities"));
+    }
+
+    #[test]
+    fn test_schema_has_no_defs() {
+        use crate::mcp::tests::assert_no_defs;
+        assert_no_defs::<GetGraphMetaTool>();
+    }
+}

--- a/crates/mm-server/src/mcp/mod.rs
+++ b/crates/mm-server/src/mcp/mod.rs
@@ -12,6 +12,7 @@ pub mod find_related_entities;
 pub mod find_relationships;
 pub mod get_entity;
 pub mod get_git_status;
+pub mod get_graph_meta;
 pub mod get_project_context;
 pub mod get_task;
 pub mod list_projects;
@@ -37,6 +38,7 @@ pub use find_related_entities::FindRelatedEntitiesTool;
 pub use find_relationships::FindRelationshipsTool;
 pub use get_entity::GetEntityTool;
 pub use get_git_status::GetGitStatusTool;
+pub use get_graph_meta::GetGraphMetaTool;
 pub use get_project_context::GetProjectContextTool;
 pub use get_task::GetTaskTool;
 pub use list_projects::ListProjectsTool;
@@ -63,6 +65,7 @@ tool_box!(
         DeleteTaskTool,
         GetEntityTool,
         GetGitStatusTool,
+        GetGraphMetaTool,
         GetProjectContextTool,
         ListProjectsTool,
         UpdateEntityTool,
@@ -100,6 +103,7 @@ impl MMTools {
             MMTools::DeleteTaskTool(tool) => tool.call_tool(ports).await,
             MMTools::GetEntityTool(tool) => tool.call_tool(ports).await,
             MMTools::GetGitStatusTool(tool) => tool.call_tool(ports).await,
+            MMTools::GetGraphMetaTool(tool) => tool.call_tool(ports).await,
             MMTools::GetProjectContextTool(tool) => tool.call_tool(ports).await,
             MMTools::ListProjectsTool(tool) => tool.call_tool(ports).await,
             MMTools::UpdateEntityTool(tool) => tool.call_tool(ports).await,
@@ -124,6 +128,7 @@ impl MMTools {
             MMTools::DeleteTaskTool(_) => DeleteTaskTool::json_schema(),
             MMTools::GetEntityTool(_) => GetEntityTool::json_schema(),
             MMTools::GetGitStatusTool(_) => GetGitStatusTool::json_schema(),
+            MMTools::GetGraphMetaTool(_) => GetGraphMetaTool::json_schema(),
             MMTools::GetProjectContextTool(_) => GetProjectContextTool::json_schema(),
             MMTools::ListProjectsTool(_) => ListProjectsTool::json_schema(),
             MMTools::UpdateEntityTool(_) => UpdateEntityTool::json_schema(),


### PR DESCRIPTION
## Summary
- implement `get_graph_meta` operation in mm-core
- expose new `get_graph_meta` MCP tool in mm-server
- document new tool in README
- add tests for the new operation and tool
- fix constant depth of 5 in `get_graph_meta` implementation and docs

## Testing
- `just validate`


------
https://chatgpt.com/codex/tasks/task_e_685cec861794832794883023eb6df76e