### PR TITLE
Add multi-label filtering for list_tasks tool

### DIFF
--- a/crates/mm-cli/src/main.rs
+++ b/crates/mm-cli/src/main.rs
@@ -122,9 +122,9 @@ enum TasksSubcommandType {
         /// Project name to list tasks for
         #[arg(long)]
         project: Option<String>,
-        /// Lifecycle label to filter by
-        #[arg(long)]
-        lifecycle: Option<String>,
+        /// Labels to filter by
+        #[arg(long, value_delimiter = ',', num_args = 1..)]
+        labels: Vec<String>,
         /// Output results in JSON format
         #[arg(long)]
         json: bool,
@@ -253,12 +253,12 @@ async fn run(args: Args) -> anyhow::Result<()> {
             match tasks_subcommand.command {
                 TasksSubcommandType::List {
                     project,
-                    lifecycle,
+                    labels,
                     json,
                 } => {
                     let tool = ListTasksTool {
                         project_name: project,
-                        lifecycle,
+                        labels,
                     };
                     let result = tool
                         .call_tool(&ports)

--- a/crates/mm-server/src/mcp/list_tasks.rs
+++ b/crates/mm-server/src/mcp/list_tasks.rs
@@ -8,14 +8,14 @@ use serde::{Deserialize, Serialize};
 pub struct ListTasksTool {
     /// Optional project name
     pub project_name: Option<String>,
-    /// Optional lifecycle label to filter by
-    pub lifecycle: Option<String>,
+    /// Labels to filter by
+    pub labels: Vec<String>,
 }
 
 impl ListTasksTool {
     generate_call_tool!(
         self,
-        ListTasksCommand { project_name => self.project_name.clone(), lifecycle => self.lifecycle.clone() },
+        ListTasksCommand { project_name => self.project_name.clone(), labels => self.labels.clone() },
         list_tasks
     );
 }
@@ -64,7 +64,7 @@ mod tests {
 
         let tool = ListTasksTool {
             project_name: None,
-            lifecycle: None,
+            labels: vec![],
         };
         let result = tool.call_tool(&ports).await.unwrap();
         let text = result.content[0].as_text_content().unwrap().text.clone();


### PR DESCRIPTION
## Summary
- update ListTasksCommand to take `Vec<String>` for labels
- adjust ListTasksTool and CLI to match new signature
- update tests to use vector labels

## Testing
- `just validate`


------
https://chatgpt.com/codex/tasks/task_e_685ced800f2c832788cc95761b9f87d0