### PR TITLE
Use tabled for formatted task lists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1476,6 +1482,7 @@ dependencies = [
  "mm-git-git2",
  "mm-server",
  "serde_json",
+ "tabled",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1761,6 +1768,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "papergrid"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1967,6 +1985,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
  "syn 2.0.104",
 ]
 
@@ -2729,6 +2769,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tabled"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+ "testing_table",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
+dependencies = [
+ "heck",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2746,6 +2810,15 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "testing_table"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
+dependencies = [
+ "unicode-width",
+]
 
 [[package]]
 name = "thiserror"
@@ -3107,6 +3180,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "untrusted"

--- a/crates/mm-cli/Cargo.toml
+++ b/crates/mm-cli/Cargo.toml
@@ -17,3 +17,4 @@ tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 anyhow = "1.0"
 serde_json = { workspace = true }
+tabled = "0.20"

--- a/crates/mm-cli/src/lib.rs
+++ b/crates/mm-cli/src/lib.rs
@@ -1,20 +1,29 @@
+use tabled::{Table, Tabled};
+
+#[derive(Tabled)]
+struct TaskRow<'a> {
+    #[tabled(rename = "Name")]
+    name: &'a str,
+    #[tabled(rename = "Status")]
+    status: &'a str,
+    #[tabled(rename = "Priority")]
+    priority: &'a str,
+    #[tabled(rename = "Due")]
+    due: &'a str,
+}
+
 pub fn format_tasks_table(tasks: &[serde_json::Value]) -> String {
-    let mut output = String::new();
-    output.push_str(&format!(
-        "{:<40} {:<10} {:<8} Due\n",
-        "Name", "Status", "Priority"
-    ));
-    for t in tasks {
-        let name = t["name"].as_str().unwrap_or("");
-        let status = t["properties"]["status"].as_str().unwrap_or("");
-        let priority = t["properties"]["priority"].as_str().unwrap_or("");
-        let due = t["properties"]["due_date"].as_str().unwrap_or("");
-        output.push_str(&format!(
-            "{:<40} {:<10} {:<8} {}\n",
-            name, status, priority, due
-        ));
-    }
-    output
+    let rows: Vec<TaskRow> = tasks
+        .iter()
+        .map(|t| TaskRow {
+            name: t["name"].as_str().unwrap_or(""),
+            status: t["properties"]["status"].as_str().unwrap_or(""),
+            priority: t["properties"]["priority"].as_str().unwrap_or(""),
+            due: t["properties"]["due_date"].as_str().unwrap_or(""),
+        })
+        .collect();
+
+    Table::new(rows).to_string()
 }
 
 pub fn format_task_detail(task: &serde_json::Value) -> String {


### PR DESCRIPTION
## Summary
- display task lists with the `tabled` crate

## Testing
- `just validate`
- `cargo test -p mm-cli`

------
https://chatgpt.com/codex/tasks/task_e_685cf03104b083279afb1cb4802cf7e7