### PR TITLE
chore(cli): Simplify task subcommand JSON parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,6 +1481,7 @@ dependencies = [
  "clap",
  "mm-git-git2",
  "mm-server",
+ "rust-mcp-sdk",
  "serde_json",
  "tabled",
  "tokio",

--- a/crates/mm-cli/Cargo.toml
+++ b/crates/mm-cli/Cargo.toml
@@ -18,3 +18,4 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 anyhow = "1.0"
 serde_json = { workspace = true }
 tabled = "0.20"
+rust-mcp-sdk = { workspace = true }

--- a/crates/mm-cli/src/lib.rs
+++ b/crates/mm-cli/src/lib.rs
@@ -1,3 +1,5 @@
+use anyhow::{Result, anyhow};
+use serde_json::{self, Value};
 use tabled::{Table, Tabled};
 
 #[derive(Tabled)]
@@ -76,4 +78,16 @@ pub fn format_task_detail(task: &serde_json::Value) -> String {
         }
     }
     out
+}
+
+pub fn parse_json_result(result: &rust_mcp_sdk::schema::CallToolResult) -> Result<Value> {
+    let text = result
+        .content
+        .first()
+        .ok_or_else(|| anyhow!("No content"))?
+        .as_text_content()
+        .map_err(|e| anyhow!(e.to_string()))?
+        .text
+        .clone();
+    Ok(serde_json::from_str(&text)?)
 }

--- a/crates/mm-cli/src/main.rs
+++ b/crates/mm-cli/src/main.rs
@@ -264,8 +264,7 @@ async fn run(args: Args) -> anyhow::Result<()> {
                         .call_tool(&ports)
                         .await
                         .map_err(|e| anyhow::anyhow!(format!("{e:?}")))?;
-                    let text = result.content[0].as_text_content().unwrap().text.clone();
-                    let value: serde_json::Value = serde_json::from_str(&text)?;
+                    let value = mm_cli::parse_json_result(&result)?;
                     let tasks = value["tasks"].as_array().cloned().unwrap_or_default();
                     if json {
                         println!("{}", serde_json::to_string_pretty(&tasks)?);
@@ -284,16 +283,10 @@ async fn run(args: Args) -> anyhow::Result<()> {
                         .call_tool(&ports)
                         .await
                         .map_err(|e| anyhow::anyhow!(format!("{e:?}")))?;
-                    let text = result.content[0].as_text_content().unwrap().text.clone();
+                    let task = mm_cli::parse_json_result(&result)?;
                     if json {
-                        println!(
-                            "{}",
-                            serde_json::to_string_pretty(&serde_json::from_str::<
-                                serde_json::Value,
-                            >(&text)?)?
-                        );
+                        println!("{}", serde_json::to_string_pretty(&task)?);
                     } else {
-                        let task: serde_json::Value = serde_json::from_str(&text)?;
                         print!("{}", format_task_detail(&task));
                     }
                 }


### PR DESCRIPTION
## Summary
- add a helper for extracting JSON from MCP tool results
- use the helper when listing or viewing tasks
- include `rust-mcp-sdk` in `mm-cli`

## Testing
- `just validate`

------
https://chatgpt.com/codex/tasks/task_e_685d7d48718483278092c031d91a73cd