### PR TITLE
Add schema generator helper

### DIFF
--- a/crates/mm-server/src/mcp/tests/mod.rs
+++ b/crates/mm-server/src/mcp/tests/mod.rs
@@ -1,5 +1,15 @@
-pub fn assert_no_defs<T: mm_utils::IntoJsonSchema>() {
-    let schema = T::json_schema();
+use mm_utils::json_schema::schema_generator;
+use schemars::JsonSchema;
+use serde_json;
+
+pub fn assert_no_defs<T: JsonSchema>() {
+    let generator = schema_generator();
+    let root_schema = generator.into_root_schema_for::<T>();
+    let schema: serde_json::Map<String, serde_json::Value> = serde_json::to_value(root_schema)
+        .expect("schema serialization")
+        .as_object()
+        .cloned()
+        .expect("schema object");
     assert!(
         !schema.contains_key("$defs"),
         "Schema should not contain $defs section",

--- a/crates/mm-utils/src/json_schema.rs
+++ b/crates/mm-utils/src/json_schema.rs
@@ -1,5 +1,6 @@
 use schemars::{
     JsonSchema,
+    r#gen::SchemaGenerator,
     generate::SchemaSettings,
     transform::{AddNullable, RecursiveTransform},
 };
@@ -11,16 +12,21 @@ pub trait IntoJsonSchema {
     fn json_schema() -> serde_json::Map<String, serde_json::Value>;
 }
 
+/// Return a schema generator configured for Middle Manager schemas.
+pub fn schema_generator() -> SchemaGenerator {
+    SchemaSettings::draft2020_12()
+        .with(|s| {
+            s.meta_schema = None;
+            s.inline_subschemas = true;
+        })
+        .with_transform(RecursiveTransform(AddNullable::default()))
+        .into_generator()
+}
+
 /// Blanket implementation for all types that implement JsonSchema
 impl<T: JsonSchema> IntoJsonSchema for T {
     fn json_schema() -> serde_json::Map<String, serde_json::Value> {
-        let generator = SchemaSettings::draft2020_12()
-            .with(|s| {
-                s.meta_schema = None;
-                s.inline_subschemas = true;
-            })
-            .with_transform(RecursiveTransform(AddNullable::default()))
-            .into_generator();
+        let generator = schema_generator();
 
         // Generate the full root schema which includes all definitions
         let root_schema = generator.into_root_schema_for::<T>();


### PR DESCRIPTION
## Summary
- factor out a `schema_generator()` helper for creating the Schemars generator
- update `IntoJsonSchema` to use the helper
- revise `assert_no_defs` in mm-server tests to use the new API

## Testing
- `just validate` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_685d8b5281c48327bf4cfc9b23b56b14