### PR TITLE
Enhance Git status details

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The `memory://` scheme is dynamic: any entity name can be requested. The server 
 | `update_task` | Update a task |
 | `delete_task` | Delete a task |
 | `get_entity` | Retrieve an entity by name |
-| `get_git_status` | Get Git status for a repository path |
+| `get_git_status` | Get detailed Git status for a repository path |
 | `get_graph_meta` | List entities related to the memory graph root |
 | `get_project_context` | Retrieve context for a project |
 | `list_projects` | List known projects |
@@ -118,7 +118,9 @@ graph TD
 
 ### Git
 
-- Query repository status with `get_git_status`
+- Query repository status with `get_git_status` including staged, modified, and
+  untracked files, merge conflicts, stash count, and branch ahead/behind
+  information
 
 ## Building
 

--- a/crates/mm-core/src/operations/git/status.rs
+++ b/crates/mm-core/src/operations/git/status.rs
@@ -42,10 +42,15 @@ mod tests {
         git_repo.expect_get_status().returning(|_| {
             Ok(GitStatus {
                 branch: "main".to_string(),
+                upstream_branch: Some("origin/main".to_string()),
                 is_dirty: false,
                 ahead_by: 0,
                 behind_by: 0,
-                changed_files: vec![],
+                staged_files: vec![],
+                modified_files: vec![],
+                untracked_files: vec![],
+                conflicted_files: vec![],
+                stash_count: 0,
             })
         });
 
@@ -64,10 +69,15 @@ mod tests {
         assert!(result.is_ok());
         let status = result.unwrap();
         assert_eq!(status.branch, "main");
+        assert_eq!(status.upstream_branch.unwrap(), "origin/main");
         assert!(!status.is_dirty);
         assert_eq!(status.ahead_by, 0);
         assert_eq!(status.behind_by, 0);
-        assert!(status.changed_files.is_empty());
+        assert!(status.staged_files.is_empty());
+        assert!(status.modified_files.is_empty());
+        assert!(status.untracked_files.is_empty());
+        assert!(status.conflicted_files.is_empty());
+        assert_eq!(status.stash_count, 0);
     }
 
     #[tokio::test]

--- a/crates/mm-git-git2/tests/git2_repository.rs
+++ b/crates/mm-git-git2/tests/git2_repository.rs
@@ -27,10 +27,15 @@ async fn test_get_status_success() {
     let service = create_git_service();
     let status = service.get_status(dir.path()).await.unwrap();
     assert_eq!(status.branch, expected_branch);
+    assert!(status.upstream_branch.is_none());
     assert!(!status.is_dirty);
     assert_eq!(status.ahead_by, 0);
     assert_eq!(status.behind_by, 0);
-    assert!(status.changed_files.is_empty());
+    assert!(status.staged_files.is_empty());
+    assert!(status.modified_files.is_empty());
+    assert!(status.untracked_files.is_empty());
+    assert!(status.conflicted_files.is_empty());
+    assert_eq!(status.stash_count, 0);
 }
 
 #[tokio::test]
@@ -43,6 +48,7 @@ async fn test_get_status_nested_directory() {
     let service = create_git_service();
     let status = service.get_status(&nested).await.unwrap();
     assert_eq!(status.branch, expected_branch);
+    assert!(status.upstream_branch.is_none());
 }
 
 #[tokio::test]

--- a/crates/mm-git/src/repository.rs
+++ b/crates/mm-git/src/repository.rs
@@ -12,8 +12,9 @@ pub trait GitRepository {
 
     /// Get the status of a Git repository.
     ///
-    /// The returned [`GitStatus`] includes the current branch name, whether the
-    /// working tree has uncommitted changes, how many commits the branch is
-    /// ahead or behind its upstream, and the list of changed files.
+    /// The returned [`GitStatus`] includes the current branch name, upstream
+    /// branch information, ahead/behind counts, and detailed lists of files in
+    /// different states (staged, modified, untracked, conflicted). It also
+    /// reports whether the working tree is dirty and how many stashes exist.
     async fn get_status(&self, path: &Path) -> GitResult<GitStatus, Self::Error>;
 }

--- a/crates/mm-git/src/service.rs
+++ b/crates/mm-git/src/service.rs
@@ -39,20 +39,30 @@ mod tests {
         let mut mock = MockGitRepository::new();
         let expected = GitStatus {
             branch: "main".to_string(),
+            upstream_branch: None,
             is_dirty: false,
             ahead_by: 0,
             behind_by: 0,
-            changed_files: vec![],
+            staged_files: vec![],
+            modified_files: vec![],
+            untracked_files: vec![],
+            conflicted_files: vec![],
+            stash_count: 0,
         };
         mock.expect_get_status()
             .withf(|p| p == Path::new("/tmp/repo"))
             .returning(|_| {
                 Ok(GitStatus {
                     branch: "main".to_string(),
+                    upstream_branch: None,
                     is_dirty: false,
                     ahead_by: 0,
                     behind_by: 0,
-                    changed_files: vec![],
+                    staged_files: vec![],
+                    modified_files: vec![],
+                    untracked_files: vec![],
+                    conflicted_files: vec![],
+                    stash_count: 0,
                 })
             });
 
@@ -60,9 +70,14 @@ mod tests {
         let path = PathBuf::from("/tmp/repo");
         let status = service.get_status(&path).await.unwrap();
         assert_eq!(status.branch, expected.branch);
+        assert_eq!(status.upstream_branch, expected.upstream_branch);
         assert_eq!(status.is_dirty, expected.is_dirty);
         assert_eq!(status.ahead_by, expected.ahead_by);
         assert_eq!(status.behind_by, expected.behind_by);
-        assert_eq!(status.changed_files, expected.changed_files);
+        assert_eq!(status.staged_files, expected.staged_files);
+        assert_eq!(status.modified_files, expected.modified_files);
+        assert_eq!(status.untracked_files, expected.untracked_files);
+        assert_eq!(status.conflicted_files, expected.conflicted_files);
+        assert_eq!(status.stash_count, expected.stash_count);
     }
 }

--- a/crates/mm-git/src/status.rs
+++ b/crates/mm-git/src/status.rs
@@ -6,12 +6,22 @@ use serde::{Deserialize, Serialize};
 pub struct GitStatus {
     /// Current branch name
     pub branch: String,
+    /// Upstream branch if configured
+    pub upstream_branch: Option<String>,
     /// Whether the working tree has uncommitted changes
     pub is_dirty: bool,
     /// Number of commits the local branch is ahead of its upstream
     pub ahead_by: u32,
     /// Number of commits the local branch is behind its upstream
     pub behind_by: u32,
-    /// Paths of files that have been modified
-    pub changed_files: Vec<String>,
+    /// Paths of files that have been staged
+    pub staged_files: Vec<String>,
+    /// Paths of tracked files modified but not staged
+    pub modified_files: Vec<String>,
+    /// Paths of untracked files
+    pub untracked_files: Vec<String>,
+    /// Files with merge conflicts
+    pub conflicted_files: Vec<String>,
+    /// Number of stashes in the repository
+    pub stash_count: u32,
 }


### PR DESCRIPTION
## Summary
- expand `GitStatus` with detailed fields for staged, modified, untracked and conflicted files
- implement new logic in `Git2Repository`
- propagate new status structure through service, core operation and MCP tool
- update tests and documentation

## Testing
- `cargo fmt --all`
- `just validate` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_685d8b30e804832793d0bae453857c1d